### PR TITLE
AlgoOrderTable: connect to new :id/state/set endpoint on hf-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,9 +2301,8 @@
       }
     },
     "bfx-hf-algo-server": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bfx-hf-algo-server/-/bfx-hf-algo-server-1.2.0.tgz",
-      "integrity": "sha512-PNo85tX67ONJfbYEJfxE4KyBTlpmD+19nJVCLTkTZkj6aVJGTiLZZTTlQ8KAxAi3KK4rkJapjW5MvCLJnWENIQ==",
+      "version": "git+https://github.com/bitfinexcom/bfx-hf-algo-server.git#793440c2641b76ee2e24da3f175d8c668612433c",
+      "from": "git+https://github.com/bitfinexcom/bfx-hf-algo-server.git",
       "requires": {
         "bfx-hf-algo": "^1.2.2",
         "bfx-hf-models": "^2.0.1",
@@ -2440,7 +2439,7 @@
       }
     },
     "bfx-hf-server": {
-      "version": "git+https://github.com/bitfinexcom/bfx-hf-server.git#2f66121df870e74bb3d5896ade725c598555db7c",
+      "version": "git+https://github.com/bitfinexcom/bfx-hf-server.git#778bafe70a11b955b931004e90a2bb18e8eb9f5c",
       "from": "git+https://github.com/bitfinexcom/bfx-hf-server.git",
       "requires": {
         "bfx-api-node-util": "^1.0.0",
@@ -2454,6 +2453,7 @@
         "cors": "^2.8.5",
         "debug": "^4.1.0",
         "express": "^4.17.1",
+        "lodash": "^4.17.15",
         "ws": "^6.1.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-ui",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "engines": {
     "node": ">=6"
   },

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@blueprintjs/select": "3.1.0",
     "axios": "^0.18.0",
     "bfx-hf-algo": "git+https://github.com/bitfinexcom/bfx-hf-algo.git",
+    "bfx-hf-algo-server": "git+https://github.com/bitfinexcom/bfx-hf-algo-server.git",
     "bfx-hf-ext-plugin-bitfinex": "git+https://github.com/bitfinexcom/bfx-hf-ext-plugin-bitfinex.git",
     "bfx-hf-indicators": "bitfinexcom/bfx-hf-indicators",
     "bfx-hf-models": "git+https://github.com/bitfinexcom/bfx-hf-models.git",

--- a/src/components/AlgoOrderDefenitionsTable/AlgoOrderDefinitionsTable.js
+++ b/src/components/AlgoOrderDefenitionsTable/AlgoOrderDefinitionsTable.js
@@ -18,19 +18,9 @@ export default class AlgoOrderTable extends React.Component {
   static defaultProps = defaultProps
 
   shouldComponentUpdate(nextProps) {
-    const newAlgoOrders = nextProps.algoOrders
     const newOrders = nextProps.orders
-    const { algoOrders, orders } = this.props
-    if (orders !== newOrders) {
-      return true
-    }
-    if (newAlgoOrders.length !== algoOrders.length) {
-      return true
-    }
-
-    const isSame = newAlgoOrders.every((row, indexRow) => row.every((value, indexValue) => value === algoOrders[indexRow][indexValue]))
-
-    return !isSame
+    const { orders } = this.props
+    return JSON.stringify(orders) !== JSON.stringify(newOrders)
   }
 
   render() {
@@ -60,18 +50,39 @@ export default class AlgoOrderTable extends React.Component {
         status,
       }
     })
+    const noOrdersDialogue = (
+      <div
+        style={{
+          textAlign: 'center',
+        }}
+      >
+        <p style={{ marginTop: 70 }}>
+          No algo orders have been created yet,
+        </p>
+        <p>Head to bitfinex.com and create one.</p>
+      </div>
+    )
     return (
       <Panel
-        label='Orders'
+        label={orders.length > 0 ? 'Orders' : ''}
         contentClassName='table__wrapper'
         style={{ height: '100%' }}
       >
-        <Table
-          data={orderObjects}
-          columns={AlgoOrderDefinitionsTableColumns}
-          maxWidth={850}
-          defaultSortDirection='ASC'
-        />
+        {
+          (orders.length > 0) && (
+            <Table
+              data={orderObjects}
+              columns={AlgoOrderDefinitionsTableColumns}
+              maxWidth={850}
+              defaultSortDirection='ASC'
+            />
+          )
+        }
+        {
+          (orders.length <= 0) && (
+            noOrdersDialogue
+          )
+        }
       </Panel>
     )
   }

--- a/src/components/AlgoOrderTable/AlgoOrderTable.columns.js
+++ b/src/components/AlgoOrderTable/AlgoOrderTable.columns.js
@@ -1,10 +1,8 @@
 /* eslint-disable react/prop-types */
 import React from 'react'
 import Switch from 'react-switch'
-import { Icon } from '@blueprintjs/core'
 import { store } from '../../StoreWrapper'
-import WSHFActions from '../../redux/actions/ws-hf-server'
-
+import AlgoOrderActions from '../../redux/actions/algo-orders'
 
 export default [{
   width: 300,
@@ -15,23 +13,17 @@ export default [{
   width: 300,
   label: 'Created',
   dataKey: 'mts',
-  cellRenderer: ({ rowData = {} }) => {
-    if (typeof rowData.mts === 'string') {
-      return rowData.mts
-    }
-    return new Date(rowData.mts).toLocaleString()
-  },
+  cellRenderer: () => 'Default',
 }, {
   width: 300,
   label: 'Actions',
   dataKey: 'gid',
-  cellRenderer: ({ rowData = {}, rowIndex }) => (
+  cellRenderer: ({ rowData = {} }) => (
     <Switch
       onChange={() => {
-        store.dispatch({ type: 'CHANGE_STATUS', index: rowIndex })
-        WSHFActions.send(['as', ['update.ao', rowData.name]])
+        store.dispatch(AlgoOrderActions.changeStatus(rowData.id, !rowData.active))
       }}
-      checked={rowData.status === 'ACTIVE'}
+      checked={rowData.active}
       height={14}
       width={28}
       onColor='#9dc24a'

--- a/src/components/AlgoOrderTable/AlgoOrderTable.container.js
+++ b/src/components/AlgoOrderTable/AlgoOrderTable.container.js
@@ -18,8 +18,8 @@ const mapStateToProps = (state = {}, ownProps = {}) => {
 }
 
 const mapDispatchToProps = dispatch => ({
-  changeStatus: (index) => {
-    dispatch(AlgoOrderActions.changeStatus(index))
+  changeStatus: (id, isActive) => {
+    dispatch(AlgoOrderActions.changeStatus(id, isActive))
   },
   toggleEditor: (flag) => {
     dispatch(EditorActions.toggleEditor(flag))

--- a/src/components/AlgoOrderTable/AlgoOrderTable.js
+++ b/src/components/AlgoOrderTable/AlgoOrderTable.js
@@ -30,9 +30,7 @@ export default class AlgoOrderTable extends React.Component {
       return true
     }
 
-    const isSame = nextProps.algoOrders.every((row, indexRow) => row.every((value, indexValue) => value === algoOrders[indexRow][indexValue]))
-
-    return !isSame
+    return JSON.stringify(newAlgoOrders) !== JSON.stringify(algoOrders)
   }
 
   onRowClick({ index } = {}) {
@@ -44,21 +42,13 @@ export default class AlgoOrderTable extends React.Component {
 
   render() {
     const { algoOrders } = this.props
-
-    const orderObjects = algoOrders.map(ao => ({
-      gid: ao[0],
-      name: ALGO_NAMES[ao[1]],
-      mts: ao[4],
-      status: ao[2] ? 'ACTIVE' : 'STOPPED',
-    }))
-
     return (
       <Panel
         label='Algo Order Definitions'
         contentClassName='table__wrapper'
       >
         <Table
-          data={orderObjects}
+          data={algoOrders}
           columns={AlgoOrderTableColumns}
           maxWidth={850}
           defaultSortDirection='ASC'

--- a/src/components/HFUI/_HFUI.scss
+++ b/src/components/HFUI/_HFUI.scss
@@ -1,6 +1,7 @@
 .hfui .hfui-api-combo-dialog-menu {
-  width: 40%;
-  margin-left: 300px;
+  width: 600px;
+  margin: auto;
+  margin-top: 100px
 }
 
 .hfui.loading {

--- a/src/redux/actions/algo-orders.js
+++ b/src/redux/actions/algo-orders.js
@@ -5,7 +5,6 @@ const stopOrder = (gId) => {
   return (dispatch) => {
     return axios.get(`${HfServerConsts.HOST}/v1/orders/${gId}/stop`)
       .then((response) => {
-        // success
         dispatch({
           type: 'RECEIVE_ORDERS',
           payload: Object.values(response.data).map((v) => {
@@ -28,10 +27,22 @@ const stopOrder = (gId) => {
   }
 }
 
-function changeStatus(index) {
-  return {
-    type: 'CHANGE_STATUS',
-    index,
+function changeStatus(id, isActive) {
+  return (dispatch) => {
+    return axios.post(`${HfServerConsts.HOST}/v1/definitions/${id}/state/set`, { active: isActive })
+      .then((response) => {
+        dispatch({
+          type: 'RECEIVE_ALGO_DATA',
+          payload: response.data,
+        })
+      })
+      .catch((error) => {
+        // failed
+        console.error(error)
+      })
+      .finally(() => {
+        dispatch({ type: 'RECEIVE_ALGO_DATA_DONE' })
+      })
   }
 }
 

--- a/src/redux/reducers/algo-orders.js
+++ b/src/redux/reducers/algo-orders.js
@@ -1,10 +1,42 @@
 function getInitialState() {
   return {
     algoOrders: [
-      [42, 'bfx-ping_pong', true, null, 'Default'],
-      [42, 'bfx-iceberg', true, null, 'Default'],
-      [42, 'bfx-twap', true, null, 'Default'],
-      [42, 'bfx-accumulate_distribute', true, null, 'Default'],
+      {
+        active: false,
+        id: 'bfx-accumulate_distribute',
+        name: 'Accumulate/Distribute',
+        meta: {},
+        events: {
+          self: {}, life: {}, orders: {}, data: {}, errors: {},
+        },
+      },
+      {
+        active: false,
+        id: 'bfx-twap',
+        name: 'TWAP',
+        meta: {},
+        events: {
+          self: {}, life: {}, orders: {}, data: {}, errors: {},
+        },
+      },
+      {
+        active: true,
+        id: 'bfx-iceberg',
+        name: 'Iceberg',
+        meta: {},
+        events: {
+          self: {}, life: {}, orders: {}, errors: {},
+        },
+      },
+      {
+        active: false,
+        id: 'bfx-ping_pong',
+        name: 'Ping/Pong',
+        meta: {},
+        events: {
+          life: {}, orders: {}, errors: {},
+        },
+      },
     ],
   }
 }


### PR DESCRIPTION
Creates a new endpoint in the `bfx-hf-server` to activate/deactive a given algo definition. This pull request updates the current redux patterns to hit that endpoint. See https://github.com/bitfinexcom/bfx-hf-server/pull/5

- [x] Merger https://github.com/bitfinexcom/bfx-hf-server/pull/5
- [x] update package-lock!!!!