### PR TITLE
ga: anonymise user IP

### DIFF
--- a/src/redux/middleware/ga/index.js
+++ b/src/redux/middleware/ga/index.js
@@ -4,6 +4,7 @@ import {
 } from '../../constants/ga'
 
 const ReactGA = ua('UA-163797164-1')
+ReactGA.set('aip', '1')
 
 export default () => {
   return store => next => (action = {}) => {


### PR DESCRIPTION
This anonymises the client IP so google is not tracking the IP.
This is useful for german vendors of honey framework solutions and
also in general a nice move towards better data privacy