### PR TITLE
ui: remove encryption notice

### DIFF
--- a/src/components/CreateNewStrategyModal/CreateNewStrategyModal.js
+++ b/src/components/CreateNewStrategyModal/CreateNewStrategyModal.js
@@ -68,7 +68,6 @@ export default class CreateNewStrategyModal extends React.Component {
           />
         )}
       >
-        <p className='notice'>Your strategy will be encrypted with a password before being sent to the server</p>
 
         <Input
           type='text'


### PR DESCRIPTION
When HF UI was a real client/server application, encryption would have made sense,
but right now everything ones on the client with a hardcoded salt.

This PR removes a notice that states that we send the data encrypted to a server.