### PR TITLE
fix: same key prop for passed react element

### DIFF
--- a/src/components/TradingStatePanel/TradingStatePanel.js
+++ b/src/components/TradingStatePanel/TradingStatePanel.js
@@ -168,19 +168,18 @@ export default class TradingStatePanel extends React.Component {
           removeable={removeable}
           darkHeader
         >
-          {/* eslint-disable */}
           <PositionsTable
-            tabTitle={<>Positions {renderCounter(positions.length)}</>}
+            tabTitle={`Positions ${renderCounter(positions.length)}`}
             exID={activeExchange}
             positions={positions}
           />
           <AtomicOrdersTable
-            tabTitle={<>Atomics {renderCounter(atomicOrders.length)}</>}
+            tabTitle={`Atomics ${renderCounter(atomicOrders.length)}`}
             exID={activeExchange}
             orders={atomicOrders}
           />
           <AlgoOrdersTable
-            tabTitle={<>Algos {renderCounter(algoOrders.length)}</>}
+            tabTitle={`Algos ${renderCounter(algoOrders.length)}`}
             exID={activeExchange}
             orders={algoOrders}
           />
@@ -190,7 +189,6 @@ export default class TradingStatePanel extends React.Component {
             hideZeroBalances
             balances={balances}
           />
-          {/* eslint-enable */}
         </Panel>
       </Panel>
     )


### PR DESCRIPTION
the panel does just support strings as tab title, which are used
as render keys. when react elements are passed, the key results in
an `[Object object]` key, which repeats itself and throws a lot of
errors.