### PR TITLE
fix: Panel element with html and keys

### DIFF
--- a/src/components/TradingStatePanel/TradingStatePanel.js
+++ b/src/components/TradingStatePanel/TradingStatePanel.js
@@ -169,17 +169,35 @@ export default class TradingStatePanel extends React.Component {
           darkHeader
         >
           <PositionsTable
-            tabTitle={`Positions ${renderCounter(positions.length)}`}
+            htmlKey='Positions'
+            tabTitle={(
+              <span>
+                Positions
+                {renderCounter(positions.length)}
+              </span>
+            )}
             exID={activeExchange}
             positions={positions}
           />
           <AtomicOrdersTable
-            tabTitle={`Atomics ${renderCounter(atomicOrders.length)}`}
+            htmlKey='Atomics'
+            tabTitle={(
+              <span>
+                Atomics
+                {renderCounter(atomicOrders.length)}
+              </span>
+            )}
             exID={activeExchange}
             orders={atomicOrders}
           />
           <AlgoOrdersTable
-            tabTitle={`Algos ${renderCounter(algoOrders.length)}`}
+            htmlKey='Algos'
+            tabTitle={(
+              <span>
+                Algos
+                {renderCounter(algoOrders.length)}
+              </span>
+            )}
             exID={activeExchange}
             orders={algoOrders}
           />

--- a/src/ui/Panel/Panel.props.js
+++ b/src/ui/Panel/Panel.props.js
@@ -14,6 +14,7 @@ export const propTypes = {
   modal: PropTypes.any,
   darkHeader: PropTypes.bool,
   dark: PropTypes.bool,
+  htmlKey: PropTypes.string,
 }
 
 export const defaultProps = {

--- a/src/ui/Panel/index.js
+++ b/src/ui/Panel/index.js
@@ -46,7 +46,7 @@ export default class Panel extends React.Component {
             <ul className='hfui-panel__header-tabs'>
               {tabs.map(tab => (
                 <li
-                  key={tab.props.tabTitle}
+                  key={tab.props.htmlKey || tab.props.tabTitle}
                   className={ClassNames({ active: tab.props.tabTitle === selectedTab.props.tabTitle })}
                   onClick={() => this.setState(() => ({ selectedTab: tab }))}
                 >


### PR DESCRIPTION
support html in our panels now by introducing custom keys, because
we can't derive keys from passed html / react elements.

require for the positions counter.