### PR TITLE
start-api-server: make api urls configurable

### DIFF
--- a/scripts/start-api-server.js
+++ b/scripts/start-api-server.js
@@ -6,12 +6,15 @@ require('bfx-hf-util/lib/catch_uncaught_errors')
 
 const startHFServer = require('bfx-hf-server')
 const os = require('os')
-const dir = `${os.homedir()}/.honeyframework`;
+const dir = `${os.homedir()}/.honeyframework`
 
 startHFServer({
   uiDBPath: `${dir}/ui.json`,
-  algoDBPath: `${dir}/algos.json`,
+  algoDBPath: `${dir}/algos.json`
+
+  // bfxWSURL: '',
+  // bfxRestURL: ''
+
   // Data servers are started by individual scripts
   // hfBitfinexDBPath: `${__dirname}/db/hf-bitfinex.json`,
-  // hfBinanceDBPath: `${__dirname}/db/hf-binance.json`,
 })


### PR DESCRIPTION
depends on https://github.com/bitfinexcom/bfx-hf-server/pull/47 (already merged)