### PR TITLE
build: don't delete bfx-hf-backtest

### DIFF
--- a/clear.sh
+++ b/clear.sh
@@ -1,4 +1,3 @@
 find ./node_modules -type d -name '*babel*' -maxdepth 1 -exec rm -rf {} \;
 find ./node_modules -type d -name '*css*'   -maxdepth 1 -exec rm -rf {} \;
 find ./node_modules -type d -name '*jest*'  -maxdepth 1 -exec rm -rf {} \;
-find ./node_modules -type d -name '*test*'  -maxdepth 1 -exec rm -rf {} \;


### PR DESCRIPTION
the regex matches one of our modules, `bfx-hf-backtest`, which was
then missing after building on the ci.