### PR TITLE
backtesting: just preselect trades

### DIFF
--- a/src/components/Backtester/forms/HistoricalForm.js
+++ b/src/components/Backtester/forms/HistoricalForm.js
@@ -58,7 +58,7 @@ export default class HistoricalForm extends React.PureComponent {
       endDate: new Date(Date.now() - (ONE_MIN * 15)),
       selectedTimeFrame: '15m',
       selectedMarket: allMarkets[exId][0],
-      trades: true,
+      trades: false,
       candles: true,
       checkboxErr: false,
       ...formState,


### PR DESCRIPTION
after receiving user feedback, this provides a better user
experience for users that select high volume pairs and test for
the first time, as result creation time  with just candles is
linear and not in relation to the trade volume.