### PR TITLE
truncate long strategy names

### DIFF
--- a/src/components/OpenExistingStrategyModal/style.scss
+++ b/src/components/OpenExistingStrategyModal/style.scss
@@ -15,3 +15,9 @@
     }
   }
 }
+
+.hfui-openexistingstrategymodal__wrapper li, .hfui-openexistingstrategymodal__wrapper  p{
+  white-space: nowrap;                      
+  overflow: hidden;              /* "overflow" value must be different from "visible" */    
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
This PR is fixing this issue: 

The strategy editor allows users to give their strategies super long names. When loading a strategy, this will cause the name to appear across multiple lines, which doesn't look great.

I would suggest cutting off long names at some point and perhaps setting up a limit (i.e. "Name of strat...")

After saving a strategy with a super long name, the strategy can no longer be loaded and the "Open Strategy" form bugs out when you try to select the strategy. 