### PR TITLE
fix:strategy content now stores in "content" field

### DIFF
--- a/src/redux/reducers/ui/index.js
+++ b/src/redux/reducers/ui/index.js
@@ -230,7 +230,10 @@ function reducer(state = getInitialState(), action = {}) {
       const { content = {} } = payload
       return {
         ...state,
-        ...content,
+        content: {
+          ...content,
+          ...state.content,
+        },
       }
     }
     case types.UPDATE_STRATEGY_ID: {


### PR DESCRIPTION
issue: 'exec.str' message was sent without strategy content. 
This PR making the app to include strategy content to the WS message