### PR TITLE
FIX: update exec strategy page after strategy select

### DIFF
--- a/src/components/LiveStrategyExecutor/LiveStrategyExecutor.container.js
+++ b/src/components/LiveStrategyExecutor/LiveStrategyExecutor.container.js
@@ -5,6 +5,7 @@ import { getMarkets } from '../../redux/selectors/meta'
 
 const mapStateToProps = (state = {}) => ({
   allMarkets: getMarkets(state),
+  strategyContent: state.ui.content,
 })
 
 const mapDispatchToProps = () => ({


### PR DESCRIPTION
Fix for next issue: 
When Strategy Editor / Execute is selected with no strategy, opening strategy will not update page