### PR TITLE
Fix: Expand/fix diagnostics app menu entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ yarn.lock
 todo
 /db
 /logs/*.log
+.undodir
+Session.vim

--- a/public/constants.js
+++ b/public/constants.js
@@ -1,0 +1,21 @@
+const os = require('os')
+
+const LOG_PATH = `${os.tmpdir()}/bfx-hf-ui-logs`
+const LOG_PATH_DS_BITFINEX = `${LOG_PATH}/ds-bitfinex-server.log`
+const LOG_PATH_API_SERVER = `${LOG_PATH}/api-server.log`
+
+const SCRIPT_PATH = `${__dirname}/../scripts`
+const SCRIPT_PATH_DS_BITFINEX = `${SCRIPT_PATH}/start-ds-bitfinex.js`
+const SCRIPT_PATH_API_SERVER = `${SCRIPT_PATH}/start-api-server.js`
+
+const LOCAL_STORE_CWD = `${os.homedir()}/.honeyframework`
+
+module.exports = {
+  LOG_PATH,
+  LOG_PATH_DS_BITFINEX,
+  LOG_PATH_API_SERVER,
+  SCRIPT_PATH,
+  SCRIPT_PATH_DS_BITFINEX,
+  SCRIPT_PATH_API_SERVER,
+  LOCAL_STORE_CWD
+}

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,28 +1,27 @@
 const { app } = require('electron') // eslint-disable-line
 const fs = require('fs')
-const os = require('os')
 const path = require('path')
 const { fork } = require('child_process')
-const HFUIApplication = require('./lib/app')
-
-const LOG_PATH = `${os.tmpdir()}`
-const LOG_PATH_DS_BITFINEX = `${LOG_PATH}/ds-bitfinex-server.log`
-const LOG_PATH_API_SERVER = `${LOG_PATH}/api-server.log`
-
-const SCRIPT_PATH = `${__dirname}/../scripts`
-const SCRIPT_PATH_DS_BITFINEX = `${SCRIPT_PATH}/start-ds-bitfinex.js`
-const SCRIPT_PATH_API_SERVER = `${SCRIPT_PATH}/start-api-server.js`
 const Store = require('electron-store')
+const HFUIApplication = require('./lib/app')
+const {
+  LOG_PATH,
+  LOG_PATH_DS_BITFINEX,
+  LOG_PATH_API_SERVER,
+  SCRIPT_PATH_DS_BITFINEX,
+  SCRIPT_PATH_API_SERVER,
+  LOCAL_STORE_CWD
+} = require('./constants')
 
-const dir = `${os.homedir()}/.honeyframework`;
+const REQUIRED_PATHS = [LOCAL_STORE_CWD, LOG_PATH]
 
-if (!fs.existsSync(dir)){
-    fs.mkdirSync(dir);
-}
-
-const ui = new Store({
-  cwd: dir
+REQUIRED_PATHS.forEach((dir) => {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir)
+  }
 })
+
+const ui = new Store({ cwd: LOCAL_STORE_CWD })
 
 const SCRIPT_SPAWN_OPTS = {
   env: { ELECTRON_RUN_AS_NODE: '1' },

--- a/public/lib/app_menu_template.js
+++ b/public/lib/app_menu_template.js
@@ -1,4 +1,10 @@
 const open = require('open')
+const os = require('os')
+const {
+  LOG_PATH,
+  LOG_PATH_DS_BITFINEX,
+  LOG_PATH_API_SERVER,
+} = require('../constants')
 
 module.exports = app => ([{
   label: 'Application',
@@ -25,8 +31,22 @@ module.exports = app => ([{
   submenu: [{
     label: 'Open Logs Folder',
     click: () => {
-      open(`${__dirname}/../../logs`).catch((e) => {
+      open(LOG_PATH).catch((e) => {
         console.error(`failed to open logs folder: ${e.message}`)
+      })
+    },
+  }, {
+    label: 'Open Data Server Log',
+    click: () => {
+      open(LOG_PATH_DS_BITFINEX).catch((e) => {
+        console.error(`failed to open data server log file: ${e.message}`)
+      })
+    },
+  }, {
+    label: 'Open API Server Log',
+    click: () => {
+      open(LOG_PATH_API_SERVER).catch((e) => {
+        console.error(`failed to open api server log file: ${e.message}`)
       })
     },
   }],


### PR DESCRIPTION
Currently the 'Open Logs Folder' entry in the electron `app_menu_template.js` points to the wrong location, as it has moved to `os.tmpdir()` some time ago.

This extracts those constants and fixes the path, also adding two entries for the API & DS server log files themselves.Currently the 'Open Logs Folder' entry in the electron `app_menu_template.js` points to the wrong location, as it has moved to `os.tmpdir()` some time ago.

This extracts those constants and fixes the path, also adding two entries for the API & DS server log files themselves.