### PR TITLE
clear storage after reset; fix button width

### DIFF
--- a/src/pages/Authentication/Authentication.container.js
+++ b/src/pages/Authentication/Authentication.container.js
@@ -32,6 +32,7 @@ const mapDispatchToProps = dispatch => ({ // eslint-disable-line
 
   onReset: () => {
     dispatch(WSActions.resetAuth())
+    window.localStorage.clear()
   },
 })
 

--- a/src/pages/Authentication/style.scss
+++ b/src/pages/Authentication/style.scss
@@ -96,7 +96,7 @@
     z-index: 999999;
     .hfui-button {
       margin-top: 25px;
-      width: 120px;
+      width: 140px;
       height: 30px;
       font-weight: 700;
     }


### PR DESCRIPTION
made app delete everything from localstorage after reset
updated save credentials button styles
<img width="492" alt="Снимок экрана 2021-03-04 в 12 53 54" src="https://user-images.githubusercontent.com/51406639/109953398-ae180a00-7ce8-11eb-86e4-533eb3db2e30.png">
