### PR TITLE
Fix: Tour not visible on Trading terminal 

### DIFF
--- a/src/pages/MarketData/MarketData.container.js
+++ b/src/pages/MarketData/MarketData.container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import {
   getLayouts, getActiveMarket, getActiveExchange, getFirstLogin,
+  getGuideStatusForPage,
 } from '../../redux/selectors/ui'
 import { MARKET_PAGE } from '../../redux/constants/ui'
 import UIActions from '../../redux/actions/ui'
@@ -12,7 +13,7 @@ const mapStateToProps = (state = {}) => ({
   activeMarket: getActiveMarket(state),
   exID: getActiveExchange(state),
   firstLogin: getFirstLogin(state),
-  isGuideActive: state.ui[`${MARKET_PAGE}_GUIDE_ACTIVE`],
+  isGuideActive: getGuideStatusForPage(state, MARKET_PAGE),
 
 })
 

--- a/src/pages/StrategyEditor/StrategyEditor.container.js
+++ b/src/pages/StrategyEditor/StrategyEditor.container.js
@@ -1,13 +1,13 @@
 import { connect } from 'react-redux'
 import { STRATEGY_PAGE } from '../../redux/constants/ui'
-import { getFirstLogin } from '../../redux/selectors/ui'
+import { getFirstLogin, getGuideStatusForPage } from '../../redux/selectors/ui'
 import UIActions from '../../redux/actions/ui'
 
 import StrategyEditor from './StrategyEditor'
 
 const mapStateToProps = state => ({
   firstLogin: getFirstLogin(state),
-  isGuideActive: state.ui[`${STRATEGY_PAGE}_GUIDE_ACTIVE`],
+  isGuideActive: getGuideStatusForPage(state, STRATEGY_PAGE),
   strategyId: state.ui.id,
 }) // eslint-disable-line
 

--- a/src/pages/Trading/Trading.container.js
+++ b/src/pages/Trading/Trading.container.js
@@ -9,6 +9,7 @@ import {
   getActiveExchange,
   getIsRefillBalanceModalVisible,
   getFirstLogin,
+  getGuideStatusForPage,
 } from '../../redux/selectors/ui'
 
 import Trading from './Trading'
@@ -21,7 +22,7 @@ const mapStateToProps = (state = {}) => ({
   apiClientConnected: apiClientConnected(state),
   hasActiveAlgoOrders: getHasActiveAlgoOrders(state),
   isRefillBalanceModalVisible: getIsRefillBalanceModalVisible(state),
-  isGuideActive: state.ui[`${TRADING_PAGE}_GUIDE_ACTIVE`],
+  isGuideActive: getGuideStatusForPage(state, TRADING_PAGE),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/pages/Trading/Trading.js
+++ b/src/pages/Trading/Trading.js
@@ -37,9 +37,9 @@ export default class Trading extends React.PureComponent {
   static defaultProps ={
     firstLogin: false,
     showAlgoModal: false,
-    isGuideActive: false,
     apiClientConnected: false,
     hasActiveAlgoOrders: false,
+    isGuideActive: true,
     changeRefillBalanceModalState: () => {},
   }
 
@@ -100,6 +100,7 @@ export default class Trading extends React.PureComponent {
       isRefillBalanceModalVisible,
     } = this.props
     const { steps } = this.state
+    console.log(isGuideActive, firstLogin)
     const commonComponentProps = {
       dark: true,
       moveable: true,

--- a/src/pages/Trading/Trading.js
+++ b/src/pages/Trading/Trading.js
@@ -100,7 +100,6 @@ export default class Trading extends React.PureComponent {
       isRefillBalanceModalVisible,
     } = this.props
     const { steps } = this.state
-    console.log(isGuideActive, firstLogin)
     const commonComponentProps = {
       dark: true,
       moveable: true,

--- a/src/redux/reducers/ui/index.js
+++ b/src/redux/reducers/ui/index.js
@@ -235,7 +235,6 @@ function reducer(state = getInitialState(), action = {}) {
     }
     case types.FINISH_GUIDE: {
       const page = payload
-      console.log({ [`${page}_GUIDE_ACTIVE`]: false })
       return {
         ...state,
         [`${page}_GUIDE_ACTIVE`]: false,

--- a/src/redux/reducers/ui/index.js
+++ b/src/redux/reducers/ui/index.js
@@ -34,7 +34,7 @@ function getInitialState() {
     previousMarket: null,
     previousExchange: null,
     remoteVersion: null,
-    firstLogin: true,
+    firstLogin: false,
     isPaperTrading: false,
     TRADING_PAGE_IS_GUIDE_ACTIVE: true,
     isTradingModeModalVisible: false,
@@ -235,6 +235,7 @@ function reducer(state = getInitialState(), action = {}) {
     }
     case types.FINISH_GUIDE: {
       const page = payload
+      console.log({ [`${page}_GUIDE_ACTIVE`]: false })
       return {
         ...state,
         [`${page}_GUIDE_ACTIVE`]: false,

--- a/src/redux/selectors/ui/get_guide_status_for_page.js
+++ b/src/redux/selectors/ui/get_guide_status_for_page.js
@@ -1,0 +1,8 @@
+import _get from 'lodash/get'
+import { REDUCER_PATHS } from '../../config'
+
+const path = REDUCER_PATHS.UI
+
+export default (state, page) => {
+  return _get(state, `${path}.${page}_GUIDE_ACTIVE`, true)
+}

--- a/src/redux/selectors/ui/index.js
+++ b/src/redux/selectors/ui/index.js
@@ -14,6 +14,7 @@ import getIsRefillBalanceModalVisible from './get_is_refill_balance_modal_visibl
 import getIsPaperTrading from './get_is_paper_trading'
 import getFirstLogin from './get_first_login'
 import getCurrentMode from './get_current_mode'
+import getGuideStatusForPage from './get_guide_status_for_page'
 
 export {
   getRemoteVersion,
@@ -32,4 +33,5 @@ export {
   getIsPaperTrading,
   getFirstLogin,
   getCurrentMode,
+  getGuideStatusForPage,
 }


### PR DESCRIPTION
Full description: https://app.asana.com/0/1125859137800433/1200010701660159/f

Fixed guide tour on the Trading Page
Refactored code 
Added dedicated selectors

<img width="1792" alt="Снимок экрана 2021-03-10 в 13 40 37" src="https://user-images.githubusercontent.com/51406639/110623934-347b9280-81a6-11eb-9bd3-709d14ccff20.png">

