### PR TITLE
(fix) orderform: show base and quote currency

### DIFF
--- a/src/components/OrderForm/OrderForm.helpers.js
+++ b/src/components/OrderForm/OrderForm.helpers.js
@@ -34,8 +34,8 @@ const COMPONENTS_FOR_ID = {
 export const CONVERT_LABELS_TO_PLACEHOLDERS = false
 
 const marketToQuoteBase = market => ({
-  QUOTE: market.q,
-  BASE: market.b,
+  QUOTE: market.quote,
+  BASE: market.base,
 })
 
 const renderString = (str, renderData) => {


### PR DESCRIPTION
Task: [Trading Terminal: show base and quote currency in the order form]
(https://app.asana.com/0/1125859137800433/1199637468764447/f)
Sub-task: [Show base, quote currency for Price, Amount labels](https://app.asana.com/0/0/1200044397612902/f)

Before:
<img width="375" alt="Screenshot 2021-03-11 at 1 10 06 PM" src="https://user-images.githubusercontent.com/29878604/110752394-38bdb380-826b-11eb-99f6-a47d00b687c3.png">

After:
<img width="375" alt="Screenshot 2021-03-11 at 1 09 10 PM 1" src="https://user-images.githubusercontent.com/29878604/110752425-4410df00-826b-11eb-8647-7232378846d4.png">
