### PR TITLE
Hide strategy editor execute tab

### DIFF
--- a/src/pages/StrategyEditor/StrategyEditor.js
+++ b/src/pages/StrategyEditor/StrategyEditor.js
@@ -7,7 +7,7 @@ import Panel from '../../ui/Panel'
 import Markdown from '../../ui/Markdown'
 import StatusBar from '../../components/StatusBar'
 import Backtester from '../../components/Backtester'
-import LiveStrategyExecutor from '../../components/LiveStrategyExecutor'
+// import LiveStrategyExecutor from '../../components/LiveStrategyExecutor'
 import ExchangeInfoBar from '../../components/ExchangeInfoBar'
 import TradingModeModal from '../../components/TradingModeModal'
 import { propTypes, defaultProps } from './StrategyEditor.props'
@@ -168,13 +168,14 @@ export default class StrategyEditorPage extends React.Component {
                   indicators={indicators}
                 />
               </div>
-              <div
-                tabtitle='Execute' // lowercase name for div is requiered
-              >
-                <LiveStrategyExecutor
-                  strategyContent={strategyContent}
-                />
-              </div>
+              {/* hidden until this feature will be implemented
+                <div
+                  tabtitle='Execute'
+                >
+                  <LiveStrategyExecutor
+                    strategyContent={strategyContent}
+                  />
+                </div> */}
             </Panel>
           </div>
         </div>


### PR DESCRIPTION
#### PR description
-  Hidden `Execute` tab in Strategy Editor until the feature will be fully implemented

<img width="463" alt="hide-execute" src="https://user-images.githubusercontent.com/41899906/111309910-19f15f80-8665-11eb-816c-2cf92d698b3b.png">
