### PR TITLE
fix: button overlay on the calendar

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -46,6 +46,10 @@ body button {
   flex-direction: row;
 }
 
+.react-datepicker-popper {
+  z-index: 3;
+}
+
 .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle,
 .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle::before {
   border-top: none;


### PR DESCRIPTION
Bug fix for calendar overlapping button

Task: [UI: Backtesting: "Use Candles" and "Use Trades" Checks Remain Active While Selecting Date](https://app.asana.com/0/1125859137800433/1199182620003269/f)

Before:
![bfx_0](https://user-images.githubusercontent.com/35810911/111628739-75982600-87e8-11eb-8c12-b4828da4b08b.gif)

After:
![bfx_1](https://user-images.githubusercontent.com/35810911/111628764-7af57080-87e8-11eb-8aca-5fa58fbce67d.gif)