### PR TITLE
Added highlighting for P/L & P/L % cols

### DIFF
--- a/src/components/PositionsTable/PositionsTable.columns.js
+++ b/src/components/PositionsTable/PositionsTable.columns.js
@@ -28,12 +28,20 @@ export default ({ exID, authToken, closePosition }) => [{
   label: 'P/L',
   dataKey: 'pl',
   width: 100,
-  cellRenderer: ({ rowData = {} }) => preparePrice(rowData.pl),
+  cellRenderer: ({ rowData = {} }) => ( // eslint-disable-line
+    <span className={rowData.pl < 0 ? 'hfui-red' : 'hfui-green'}>
+      {preparePrice(rowData.pl)}
+    </span>
+  ),
 }, {
   label: 'P/L %',
   dataKey: 'plPerc',
   width: 100,
-  cellRenderer: ({ rowData = {} }) => (rowData.plPerc || 0).toFixed(4),
+  cellRenderer: ({ rowData = {} }) => ( // eslint-disable-line
+    <span className={rowData.plPerc && rowData.plPerc < 0 ? 'hfui-red' : 'hfui-green'}>
+      {(rowData.plPerc || 0).toFixed(4)}
+    </span>
+  ),
 }, {
   label: 'Funding Cost',
   dataKey: 'marginFunding',


### PR DESCRIPTION
Task: [Align positions table colors with web-app](https://app.asana.com/0/1125859137800433/1198968550128741/f)

Before:
![bfx-colour4](https://user-images.githubusercontent.com/35810911/111834640-cd6b8580-88eb-11eb-9e71-6b2900b21f41.png)

After:
![bf-colour3](https://user-images.githubusercontent.com/35810911/111834664-d4929380-88eb-11eb-8113-925a669a97c2.png)
