### PR TITLE
Notifying users to enter Paper Trading keys

### DIFF
--- a/src/components/OrderForm/Modals/SubmitAPIKeysModal/SubmitAPIKeysModal.js
+++ b/src/components/OrderForm/Modals/SubmitAPIKeysModal/SubmitAPIKeysModal.js
@@ -48,13 +48,13 @@ export default class SubmitAPIKeysModal extends React.Component {
 
   render() {
     const {
-      exID, onClose, apiClientConnecting, isModal = true,
+      exID, onClose, apiClientConnecting, isPaperTrading, isModal = true,
     } = this.props
     const { apiKey, apiSecret, error } = this.state
 
     return (
       <OrderFormModal
-        title={`SUBMIT API KEYS FOR ${exID.toUpperCase()}`}
+        title={`SUBMIT ${isPaperTrading ? 'PAPER TRADING' : ''} API KEYS FOR ${exID.toUpperCase()}`}
         icon='icon-api'
         isModal={isModal}
         apiClientConnecting={apiClientConnecting}

--- a/src/components/OrderForm/Modals/SubmitAPIKeysModal/SubmitAPIKeysModal.props.js
+++ b/src/components/OrderForm/Modals/SubmitAPIKeysModal/SubmitAPIKeysModal.props.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 export const propTypes = {
   onSubmit: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
+  isPaperTrading: PropTypes.bool.isRequired,
 }
 
 export const defaultProps = {}

--- a/src/components/OrderForm/Modals/UnconfiguredModal/UnconfiguredModal.js
+++ b/src/components/OrderForm/Modals/UnconfiguredModal/UnconfiguredModal.js
@@ -9,7 +9,7 @@ export default class UnconfiguredModal extends React.PureComponent {
   static defaultProps = defaultProps
 
   render() {
-    const { onClick, exID } = this.props
+    const { onClick, exID, isPaperTrading } = this.props
 
     return (
       <OrderFormModal
@@ -19,7 +19,9 @@ export default class UnconfiguredModal extends React.PureComponent {
         onClick={onClick}
         content={[
           <p key='a' className='underline'>
-            Submit API keys for
+            Submit
+            {isPaperTrading ? ' Paper Trading ' : ' '}
+            API keys for
             {` ${_capitalize(exID)}`}
           </p>,
         ]}

--- a/src/components/OrderForm/Modals/UnconfiguredModal/UnconfiguredModal.props.js
+++ b/src/components/OrderForm/Modals/UnconfiguredModal/UnconfiguredModal.props.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 export const propTypes = {
   onClick: PropTypes.func.isRequired,
   exID: PropTypes.string.isRequired,
+  isPaperTrading: PropTypes.bool.isRequired,
 }
 
 export const defaultProps = {}

--- a/src/components/OrderForm/OrderForm.container.js
+++ b/src/components/OrderForm/OrderForm.container.js
@@ -11,7 +11,7 @@ import {
   getAPIClientStates, getAuthToken, getAPICredentials,
 } from '../../redux/selectors/ws'
 import {
-  getComponentState, getActiveExchange, getActiveMarket, getCurrentMode,
+  getComponentState, getActiveExchange, getActiveMarket, getCurrentMode, getIsPaperTrading,
 } from '../../redux/selectors/ui'
 
 const debug = Debug('hfui:c:order-form')
@@ -32,6 +32,7 @@ const mapStateToProps = (state = {}, ownProps = {}) => {
     apiCredentials: getAPICredentials(state),
     favoritePairs,
     mode: getCurrentMode(state),
+    isPaperTrading: getIsPaperTrading(state),
   }
 }
 

--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -387,7 +387,7 @@ export default class OrderForm extends React.Component {
     const {
       onRemove, orders, apiClientStates, apiCredentials, moveable, removeable,
       showExchange, showMarket, favoritePairs, savePairs, authToken, onChangeMarket, allMarkets,
-      activeExchange, activeMarket, mode,
+      activeExchange, activeMarket, mode, isPaperTrading,
     } = this.props
 
     const {
@@ -460,6 +460,7 @@ export default class OrderForm extends React.Component {
                   key='unconfigured'
                   exID={currentExchange}
                   onClick={this.onToggleConfigureModal}
+                  isPaperTrading={isPaperTrading}
                 />
               ),
 
@@ -470,6 +471,7 @@ export default class OrderForm extends React.Component {
                   onSubmit={this.onSubmitAPIKeys}
                   exID={currentExchange}
                   apiClientConnecting={apiClientConnecting}
+                  isPaperTrading={isPaperTrading}
                 />
               ),
             ]}

--- a/src/components/OrderForm/style.scss
+++ b/src/components/OrderForm/style.scss
@@ -491,6 +491,10 @@
       height: calc(100% - 32px);
     }
 
+    > p {
+      text-align: center;
+    }
+
     > i {
       font-size: 38px;
       height: 38px;


### PR DESCRIPTION
ASANA Ticket: [When inside HF on paper trading specify that users need to enter paper trading keys](https://app.asana.com/0/1125859137800433/1200101612218997/f)

Note: you have to run `npm run build-css` after you've pulled these changes.

UI Demonstration:
![bfx-es1](https://user-images.githubusercontent.com/35810911/112829785-2623e680-9081-11eb-8ee2-a1cb7ac352d4.png)
![bfx-es2](https://user-images.githubusercontent.com/35810911/112829705-042a6400-9081-11eb-9377-3999b1870f14.png)
