### PR TITLE
Fixed 'reduce only' field being displayed for exchange trading

### DIFF
--- a/src/components/OrderForm/OrderForm.helpers.js
+++ b/src/components/OrderForm/OrderForm.helpers.js
@@ -216,6 +216,10 @@ const renderLayoutField = ({
     return null
   }
 
+  if (fieldDef.trading && !fieldDef.trading.includes(fieldData._context)) {
+    return null
+  }
+
   return renderLayoutComponent({
     componentDef: fieldDef,
     fieldName: field,

--- a/src/orders/bitfinex/fok.js
+++ b/src/orders/bitfinex/fok.js
@@ -51,6 +51,7 @@ export default () => ({
     reduceonly: {
       component: 'input.checkbox',
       label: 'REDUCE-ONLY',
+      trading: ['m'],
       default: false,
     },
 

--- a/src/orders/bitfinex/ioc.js
+++ b/src/orders/bitfinex/ioc.js
@@ -51,6 +51,7 @@ export default () => ({
     reduceonly: {
       component: 'input.checkbox',
       label: 'REDUCE-ONLY',
+      trading: ['m'],
       default: false,
     },
 

--- a/src/orders/bitfinex/market.js
+++ b/src/orders/bitfinex/market.js
@@ -47,6 +47,7 @@ export default () => ({
     reduceonly: {
       component: 'input.checkbox',
       label: 'REDUCE-ONLY',
+      trading: ['m'], // margin
       default: false,
     },
 

--- a/src/orders/bitfinex/stop.js
+++ b/src/orders/bitfinex/stop.js
@@ -72,6 +72,7 @@ export default () => ({
     reduceonly: {
       component: 'input.checkbox',
       label: 'REDUCE-ONLY',
+      trading: ['m'],
       default: false,
     },
 

--- a/src/orders/bitfinex/stop_limit.js
+++ b/src/orders/bitfinex/stop_limit.js
@@ -75,6 +75,7 @@ export default () => ({
     reduceonly: {
       component: 'input.checkbox',
       label: 'REDUCE-ONLY',
+      trading: ['m'],
       default: false,
     },
 

--- a/src/orders/bitfinex/trailing_stop.js
+++ b/src/orders/bitfinex/trailing_stop.js
@@ -72,6 +72,7 @@ export default () => ({
     reduceonly: {
       component: 'input.checkbox',
       label: 'REDUCE-ONLY',
+      trading: ['m'],
       default: false,
     },
 


### PR DESCRIPTION
ASANA Ticket: [UI: Remove Reduce only checkbox from Exchange orders](https://app.asana.com/0/1125859137800433/1200016200363070/f)

Before:
![bfx-ui-ro2](https://user-images.githubusercontent.com/35810911/112990904-17f3ca00-9156-11eb-9694-432658100df4.gif)

After:
![bfx-ui-ro1](https://user-images.githubusercontent.com/35810911/112990664-d5ca8880-9155-11eb-8150-3d42d63ccd35.gif)
