### PR TITLE
Added reduce-only into limit order

### DIFF
--- a/src/orders/bitfinex/limit.js
+++ b/src/orders/bitfinex/limit.js
@@ -7,7 +7,7 @@ export default () => ({
 
   generateOrder: (data = {}, symbol, context) => {
     const {
-      oco, hidden, postonly, tif, tifDate, ocoStop, price, amount, lev,
+      oco, hidden, postonly, tif, reduceonly, tifDate, ocoStop, price, amount, lev,
     } = data
 
     if (tif && (!_isFinite(tifDate) || tifDate === 0)) {
@@ -22,6 +22,7 @@ export default () => ({
       symbol,
       postonly,
       oco,
+      reduceonly,
     }
 
     if (oco) {
@@ -41,7 +42,7 @@ export default () => ({
 
   header: {
     component: 'ui.checkbox_group',
-    fields: ['oco', 'hidden', 'postonly', 'tif'],
+    fields: ['oco', 'hidden', 'postonly', 'tif', 'reduceonly'],
   },
 
   sections: [{
@@ -85,6 +86,13 @@ export default () => ({
   }],
 
   fields: {
+    reduceonly: {
+      component: 'input.checkbox',
+      label: 'REDUCE-ONLY',
+      trading: ['m'],
+      default: false,
+    },
+
     hidden: {
       component: 'input.checkbox',
       label: 'HIDDEN',


### PR DESCRIPTION
ASANA Ticket: [[Margin Trading]: Reduce only flag is missing on margin limit orders](https://app.asana.com/0/1125859137800433/1200136010718941/f)

UI Demo:
![Screenshot from 2021-04-05 14-52-41](https://user-images.githubusercontent.com/35810911/113571330-ba53f780-9605-11eb-864f-c6f295820e3d.png)
![Screenshot from 2021-04-05 14-56-25](https://user-images.githubusercontent.com/35810911/113571474-f8e9b200-9605-11eb-82e0-df71f1d471cd.png)

