### PR TITLE
Fixed dropdown TWAP overlap

### DIFF
--- a/src/components/OrderForm/style.scss
+++ b/src/components/OrderForm/style.scss
@@ -11,7 +11,7 @@
     padding-left: 8px;
 
     p {
-      width: calc(100% - 20px);
+      width: calc(100% - 32px);
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;

--- a/src/ui/Dropdown/style.scss
+++ b/src/ui/Dropdown/style.scss
@@ -66,7 +66,6 @@
   p {
     line-height: 35px;
     flex-shrink: 0;
-    flex: 1;
 
     &.with-icon {
       padding-left: 32px;


### PR DESCRIPTION
ASANA Ticket: [UI: TWAP: Dropdown icon overlaps with settings for "Price Condition" on a custom "Price Target"](https://app.asana.com/0/1125859137800433/1199921049101626/f)

UI Demonstration:
![Screenshot from 2021-04-06 16-39-46](https://user-images.githubusercontent.com/35810911/113721695-4423c380-96df-11eb-8ae4-d52038f27866.png)
