### PR TITLE
fix: close all background services

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -43,7 +43,7 @@ const childAPIProcess = fork(path.resolve(SCRIPT_PATH_API_SERVER), [], {
 new HFUIApplication({ // eslint-disable-line
   app,
   onExit: () => {
-    childAPIProcess.kill()
-    childDSProcess.kill()
+    childAPIProcess.kill('SIGKILL')
+    childDSProcess.kill('SIGKILL')
   },
 })

--- a/public/lib/app.js
+++ b/public/lib/app.js
@@ -70,12 +70,8 @@ module.exports = class HFUIApplication {
   }
 
   onAllWindowsClosed() {
-    if (process.platform !== 'darwin') {
-      this.app.quit()
-    }
+    this.onExitCB()
 
-    if (this.onExitCB) {
-      this.onExitCB()
-    }
+    this.app.quit()
   }
 }


### PR DESCRIPTION
previously, on OSX child processes stayed open, now `SIGKILL` is
sent and the background services exit properly.

additionally on darwin the app is completely stopped, as a
hybernate process does not make sense for the app.