### PR TITLE
(improvement) strategy editor: remember selected strategy after page change

### DIFF
--- a/src/components/NotificationsSidebar/Notification.js
+++ b/src/components/NotificationsSidebar/Notification.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import ClassNames from 'classnames'
+import _includes from 'lodash/includes'
+import _toLower from 'lodash/toLower'
 // import { Icon } from 'react-fa'
 import check from './check.svg'
 import error from './error.svg'
@@ -40,7 +42,7 @@ export default class Notification extends React.PureComponent {
         break
 
       case 'error':
-        if (text.toLowerCase().includes('invalid password')) {
+        if (_includes(_toLower(text), 'invalid password')) {
           icon = <img src={pass} alt='password error' />
         } else {
           icon = <img src={error} alt='error' />
@@ -49,7 +51,7 @@ export default class Notification extends React.PureComponent {
         break
 
       case 'info':
-        if (text.toLowerCase().includes('cleared user credentials & data')) {
+        if (_includes(_toLower(text), 'cleared user credentials & data')) {
           icon = <img src={clear} alt='clear' />
         }
 

--- a/src/components/StrategyEditor/StrategyEditor.container.js
+++ b/src/components/StrategyEditor/StrategyEditor.container.js
@@ -11,6 +11,7 @@ const mapStateToProps = (state = {}) => ({
   activeMarket: getActiveMarket(state),
   authToken: getAuthToken(state),
   strategyId: getStrategyId(state),
+  strategyContent: state.ui.content,
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/StrategyEditor/StrategyEditor.js
+++ b/src/components/StrategyEditor/StrategyEditor.js
@@ -408,6 +408,7 @@ export default class StrategyEditor extends React.PureComponent {
       createNewStrategyModalOpen,
       openExistingStrategyModalOpen,
     } = this.state
+
     if (!strategy || _isEmpty(strategy)) {
       return this.renderPanel(this.renderEmptyContent())
     }

--- a/src/components/StrategyEditor/StrategyEditor.js
+++ b/src/components/StrategyEditor/StrategyEditor.js
@@ -49,12 +49,19 @@ export default class StrategyEditor extends React.PureComponent {
     gaCreateStrategy: PropTypes.func.isRequired,
     onIndicatorsChange: PropTypes.func.isRequired,
     clearBacktestOptions: PropTypes.func.isRequired,
+    strategyContent: PropTypes.objectOf(
+      PropTypes.oneOfType([
+        PropTypes.string.isRequired,
+        PropTypes.oneOf([null]).isRequired,
+      ]),
+    ),
   }
   static defaultProps = {
     strategyId: '',
     moveable: false,
     removeable: false,
     renderResults: true,
+    strategyContent: {},
   }
 
   state = {
@@ -67,6 +74,13 @@ export default class StrategyEditor extends React.PureComponent {
     activeContent: 'defineIndicators',
     createNewStrategyModalOpen: false,
     openExistingStrategyModalOpen: false,
+  }
+
+  componentDidMount() {
+    const { strategyContent } = this.props
+    this.setState(() => ({
+      strategy: strategyContent,
+    }))
   }
 
   onCreateNewStrategy = (label, templateLabel) => {
@@ -394,7 +408,6 @@ export default class StrategyEditor extends React.PureComponent {
       createNewStrategyModalOpen,
       openExistingStrategyModalOpen,
     } = this.state
-
     if (!strategy) {
       return this.renderPanel(this.renderEmptyContent())
     }

--- a/src/components/StrategyEditor/StrategyEditor.js
+++ b/src/components/StrategyEditor/StrategyEditor.js
@@ -408,7 +408,7 @@ export default class StrategyEditor extends React.PureComponent {
       createNewStrategyModalOpen,
       openExistingStrategyModalOpen,
     } = this.state
-if (!strategy || _isEmpty(strategy)) {
+    if (!strategy || _isEmpty(strategy)) {
       return this.renderPanel(this.renderEmptyContent())
     }
 

--- a/src/components/StrategyEditor/StrategyEditor.js
+++ b/src/components/StrategyEditor/StrategyEditor.js
@@ -408,7 +408,7 @@ export default class StrategyEditor extends React.PureComponent {
       createNewStrategyModalOpen,
       openExistingStrategyModalOpen,
     } = this.state
-    if (!strategy) {
+if (!strategy || _isEmpty(strategy)) {
       return this.renderPanel(this.renderEmptyContent())
     }
 

--- a/src/pages/StrategyEditor/StrategyEditor.js
+++ b/src/pages/StrategyEditor/StrategyEditor.js
@@ -60,10 +60,6 @@ export default class StrategyEditorPage extends React.Component {
       .then(t => this.setState(() => ({ docsText: t })))
   }
 
-  componentWillUnmount() {
-    this.setContent(null)
-  }
-
   onIndicatorsChange = (indicators) => {
     // TODO: Better color generation; to save time we generate enough colors for
     //       all indicators here, but optimally we'd switch on i.constructor.ui


### PR DESCRIPTION
Description:
strategy editor: remember selected strategy after page change

steps:
1. On strategy editor, select strategy, run backtest
2. visit trading terminal/market data page
3. now it shows previously selected strategy, and clicking 'start' on backtest tab will run strategy successfully


https://user-images.githubusercontent.com/29878604/114008204-a1567b00-987f-11eb-8641-bd48d824e572.mov

