### PR TITLE
fix: broken algo modal layout

### DIFF
--- a/src/components/ActiveAlgoOrdersModal/style.scss
+++ b/src/components/ActiveAlgoOrdersModal/style.scss
@@ -4,7 +4,6 @@
   &.hfui-modal__content {
     width: 75vw;
     max-width: 1156px;
-    max-height: 483px;
     padding: 0 26px 38px 26px;
   }
 
@@ -21,12 +20,12 @@
   }
 
   .hfui-modal__actions {
-    margin-top: 30px;
+    margin-top: 10px;
   }
 
   .hfui-ao-list__wrapper {
-    overflow: scroll;
-    height: 315px;
+    overflow-y: auto;
+    max-height: 315px;
   }
 
   .hfui-ao-list__entry {
@@ -107,6 +106,7 @@
     display: flex;
     flex-direction: row;
     padding: 0px 20px;
+    margin-top: 10px;
 
     .hfui-ao-list__footer-row-elm {
       margin-right: 25px;


### PR DESCRIPTION
Fix for ActiveAlgoOrdersModal's broken layout.
* the issue is reproducible on Firefox.

Before:
![Screenshot from 2021-04-13 16-34-57](https://user-images.githubusercontent.com/35810911/114563044-95433280-9c5e-11eb-950b-059c5f0546b2.png)

After:
![Screenshot from 2021-04-13 16-37-19](https://user-images.githubusercontent.com/35810911/114563021-91afab80-9c5e-11eb-954f-be37fddf89af.png)
