### PR TITLE
fix: opening external link in the default browser

### DIFF
--- a/public/lib/app.js
+++ b/public/lib/app.js
@@ -1,7 +1,7 @@
 const url = require('url')
 const path = require('path')
 const {
-  BrowserWindow, protocol, Menu,
+  BrowserWindow, protocol, Menu, shell,
 } = require('electron') // eslint-disable-line
 
 const appMenuTemplate = require('./app_menu_template')
@@ -29,7 +29,6 @@ module.exports = class HFUIApplication {
     this.onAllWindowsClosed = this.onAllWindowsClosed.bind(this)
     this.onMainWindowClosed = this.onMainWindowClosed.bind(this)
 
-
     // increase memory size
     app.commandLine.appendSwitch('js-flags', '--max-old-space-size=2048');
     app.on('ready', this.onReady)
@@ -44,6 +43,12 @@ module.exports = class HFUIApplication {
 
     this.mainWindow = HFUIApplication.createWindow()
     this.mainWindow.on('closed', this.onMainWindowClosed)
+    this.mainWindow.webContents.on('new-window', this.handleURLRedirect)
+  }
+
+  handleURLRedirect(event, url) {
+    event.preventDefault()
+    shell.openExternal(url)
   }
 
   onReady() {
@@ -74,4 +79,6 @@ module.exports = class HFUIApplication {
 
     this.app.quit()
   }
+
+  onNewWindow
 }

--- a/public/lib/app.js
+++ b/public/lib/app.js
@@ -79,6 +79,4 @@ module.exports = class HFUIApplication {
 
     this.app.quit()
   }
-
-  onNewWindow
 }

--- a/src/components/NavbarButton/NavbarButton.js
+++ b/src/components/NavbarButton/NavbarButton.js
@@ -16,6 +16,8 @@ export default class NavbarButton extends React.PureComponent {
       return (
         <a
           href={`${external}`}
+          target='_blank'
+          rel='noopener noreferrer'
         >
           {label}
         </a>


### PR DESCRIPTION
Ticket: https://app.asana.com/0/0/1200101612219001/1200196533316186/f

Description: From now on any external link with the `target="_blank"` will be opened in the default browser instead of the Electron application.

Before:
https://www.loom.com/share/f54f9ec9eaae4263af09a73a11c68695

After:
![bfx-hf-ui-electron-fix](https://user-images.githubusercontent.com/35810911/114863212-fabe2d00-9dde-11eb-9335-3e1df27946d2.gif)
