### PR TITLE
fix: 'Bitfinex error: auth: dup' when submitting new API keys

### DIFF
--- a/src/pages/Settings/Settings.container.js
+++ b/src/pages/Settings/Settings.container.js
@@ -1,69 +1,44 @@
 import { connect } from 'react-redux'
 import Settings from './Settings'
 
-import { getExchanges, getMarkets } from '../../redux/selectors/meta'
-import UIActions from '../../redux/actions/ui'
 import WSActions from '../../redux/actions/ws'
 import GAActions from '../../redux/actions/google_analytics'
 import { getActiveAlgoOrders } from '../../redux/actions/ao'
 
-import {
-  getAPIClientStates, getAuthToken, getAPICredentials,
-} from '../../redux/selectors/ws'
+import { getAuthToken } from '../../redux/selectors/ws'
+import { getCurrentMode } from '../../redux/selectors/ui'
 
-import {
-  getComponentState, getActiveExchange, getActiveMarket,
-} from '../../redux/selectors/ui'
-
-const mapStateToProps = (state = {}, ownProps = {}) => {
-  const { layoutID, layoutI: id } = ownProps
+const mapStateToProps = (state = {}) => {
   const { ui = {} } = state
-  const { settings = {}, firstLogin } = ui
-  const {
-    chart, theme, dms, ga,
-  } = settings || {}
+  const { settings = {} } = ui
+  const { dms, ga } = settings
 
   return {
-    activeExchange: getActiveExchange(state),
-    activeMarket: getActiveMarket(state),
-    exchanges: getExchanges(state),
-    apiClientStates: getAPIClientStates(state),
-    allMarkets: getMarkets(state),
-    savedState: getComponentState(state, layoutID, 'orderform', id),
     authToken: getAuthToken(state),
-    apiCredentials: getAPICredentials(state),
-    chart,
-    theme,
     dms,
     ga,
-    firstLogin,
+    currentMode: getCurrentMode(state),
   }
 }
 
 const mapDispatchToProps = dispatch => ({
-  saveState: (layoutID, componentID, state) => {
-    dispatch(UIActions.saveComponentState({
-      state,
-      layoutID,
-      componentID,
-    }))
-  },
-
   submitAPIKeys: ({
-    exID, authToken, apiKey, apiSecret,
-  }, mode) => {
+    authToken, apiKey, apiSecret,
+  }, mode, currentMode) => {
     dispatch(WSActions.send([
       'api_credentials.save',
       authToken,
-      exID,
       apiKey,
       apiSecret,
       mode,
+      currentMode,
     ]))
   },
+
   gaUpdateSettings: () => {
     dispatch(GAActions.updateSettings())
   },
+
   updateSettings: ({
     authToken, dms, ga,
   }) => {
@@ -74,6 +49,7 @@ const mapDispatchToProps = dispatch => ({
       ga,
     ]))
   },
+
   getActiveAOs: () => dispatch(getActiveAlgoOrders()),
 })
 

--- a/src/pages/Settings/Settings.js
+++ b/src/pages/Settings/Settings.js
@@ -17,7 +17,6 @@ import {
 import {
   PAPER_MODE,
   MAIN_MODE,
-  DEFAULT_EXCHANGE,
 } from '../../redux/reducers/ui'
 import NavbarButton from '../../components/NavbarButton'
 
@@ -27,16 +26,12 @@ const isDevEnv = devEnv()
 class Settings extends React.PureComponent {
   constructor(props) {
     super(props)
-    const {
-      activeExchange,
-    } = props
 
     this.state = {
       apiKey: '',
       apiSecret: '',
       paperApiKey: '',
       paperApiSecret: '',
-      currentExchange: activeExchange,
       AUTOLOGIN_STATE: getAutoLoginState(),
     }
   }
@@ -48,27 +43,31 @@ class Settings extends React.PureComponent {
   }
 
   onSubmitAPIKeys({ apiKey, apiSecret }) {
-    const { submitAPIKeys, authToken } = this.props
-    const { currentExchange } = this.state
+    const {
+      submitAPIKeys,
+      authToken,
+      currentMode,
+    } = this.props
 
     submitAPIKeys({
       authToken,
-      exID: currentExchange,
       apiKey,
       apiSecret,
-    }, MAIN_MODE)
+    }, MAIN_MODE, currentMode)
   }
 
   onSubmitPaperAPIKeys({ paperApiKey: apiKey, paperApiSecret: apiSecret }) {
-    const { submitAPIKeys, authToken } = this.props
-    const { currentExchange } = this.state
+    const {
+      submitAPIKeys,
+      authToken,
+      currentMode,
+    } = this.props
 
     submitAPIKeys({
       authToken,
-      exID: currentExchange,
       apiKey,
       apiSecret,
-    }, PAPER_MODE)
+    }, PAPER_MODE, currentMode)
   }
 
   onSettingsSave(authToken) {
@@ -269,18 +268,17 @@ class Settings extends React.PureComponent {
 Settings.propTypes = {
   ga: PropTypes.bool,
   dms: PropTypes.bool,
-  activeExchange: PropTypes.string,
   authToken: PropTypes.string.isRequired,
   getActiveAOs: PropTypes.func.isRequired,
   submitAPIKeys: PropTypes.func.isRequired,
   updateSettings: PropTypes.func.isRequired,
   gaUpdateSettings: PropTypes.func.isRequired,
+  currentMode: PropTypes.string.isRequired,
 }
 
 Settings.defaultProps = {
   ga: null,
   dms: null,
-  activeExchange: DEFAULT_EXCHANGE,
 }
 
 export default Settings


### PR DESCRIPTION
Description:
 - fix for the "Bitfinex error: auth: dup" issue when submitting new API keys.
 - removed unused code in the Settings & Settings.container components.
 - removed obsolete exID param from 'api_credentials.save'

UI Demonstation:
![Screenshot from 2021-04-16 14-49-08](https://user-images.githubusercontent.com/35810911/115020398-10e4ef80-9eaa-11eb-9441-3b2e43f52095.png)
![Screenshot from 2021-04-16 14-50-18](https://user-images.githubusercontent.com/35810911/115020404-12161c80-9eaa-11eb-8366-322b6f760eeb.png)
