### PR TITLE
fix: doc items are not clickable

### DIFF
--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -1,6 +1,6 @@
 import { createStore, applyMiddleware, compose } from 'redux'
 import createSagaMiddleware from 'redux-saga'
-import { createHashHistory } from 'history'
+import { createBrowserHistory } from 'history'
 import { routerMiddleware } from 'connected-react-router'
 import Debug from 'debug'
 import _throttle from 'lodash/throttle'
@@ -11,7 +11,7 @@ import createRootReducer from './reducers'
 const debug = Debug('hfui:rx')
 const sagaMiddleware = createSagaMiddleware()
 
-export const history = createHashHistory()
+export const history = createBrowserHistory()
 
 const THROTTLE_MILLIS = 350
 const throttleOptions = {


### PR DESCRIPTION
ASANA Ticket: [UI: Strategy Editor: Doc items are not clickable](https://app.asana.com/0/1125859137800433/1200207509584987/f)

Description:
Only one '#' hashtag is available in the URL, which makes it impossible to use hashtag-based links in the app when using createHashHistory middleware.
Moving from `createHashHistory` to `createBrowserHistory` fixes this issue.

UI Demonstration:
![bfx-hf-ui-docs-fix](https://user-images.githubusercontent.com/35810911/115233210-273bb700-a107-11eb-9cd3-d1550754f155.gif)
