### PR TITLE
Prevent AOs modal close on overlay click

### DIFF
--- a/src/ui/Modal/Modal.js
+++ b/src/ui/Modal/Modal.js
@@ -34,7 +34,10 @@ export default class Modal extends React.PureComponent {
     return (
       <div
         className={ClassNames('hfui-modal__wrapper', { fixed })}
-        onClick={onClose}
+        onClick={(e) => {
+          e.stopPropagation()
+          return false
+        }}
       >
         <div
           className={ClassNames('hfui-modal__content', className)}


### PR DESCRIPTION
#### Task: 
- [Resume algo trade dialog should not be closed by clicking outside of dialog ](https://app.asana.com/0/1125859137800433/1200222037480528)

#### Description:
-  Prevented AOs modal from closing on overlay clicking


#### Preview:
https://user-images.githubusercontent.com/41899906/116435535-236d0a80-a854-11eb-8f2f-f0530c8e8d9a.mov
