### PR TITLE
fix: version retrieval bug

### DIFF
--- a/src/redux/sagas/ui/worker_fetch_remote_version.js
+++ b/src/redux/sagas/ui/worker_fetch_remote_version.js
@@ -1,11 +1,13 @@
 import { put, delay } from 'redux-saga/effects'
+import _head from 'lodash/head'
+import _replace from 'lodash/replace'
 import Debug from 'debug'
 import Request from 'request-promise'
 
 import UIActions from '../../actions/ui'
 
 const CHECK_INTERVAL_MS = 60 * 60 * 1000 // 1hr
-const REMOTE_MANIFEST_URL = 'https://raw.githubusercontent.com/bitfinexcom/bfx-hf-ui/master/package.json'
+const REMOTE_MANIFEST_URL = 'https://api.github.com/repos/bitfinexcom/bfx-hf-ui/tags?per_page=1'
 
 const debug = Debug('hfui:rx:s:ws-hfui:worker-fetch-remote-version')
 
@@ -14,15 +16,17 @@ export default function* () {
     let remoteManifestData
 
     try {
-      remoteManifestData = yield Request(REMOTE_MANIFEST_URL)
+      const manifest = yield Request(REMOTE_MANIFEST_URL)
+      remoteManifestData = JSON.parse(manifest)
     } catch (err) {
       debug('failed to fetch remote manifest: %s', err.message)
       return
     }
 
-    const { version } = remoteManifestData
+    let { name } = _head(remoteManifestData)
+    name = _replace(name, 'v', '')
 
-    yield put(UIActions.saveRemoteVersion(version))
+    yield put(UIActions.saveRemoteVersion(name))
     yield delay(CHECK_INTERVAL_MS)
   }
 }


### PR DESCRIPTION
ASANA Ticlet: [Fix incorrect version retrieval bug](https://app.asana.com/0/1125859137800433/1200296600486401/f)

Description: Currently the redux worker retrieves the data from `package.json` (as a string) and tries to get the `version` value from it, which will always return undefined.
This PR fixes this bug (by parsing JSON from the returned string) and uses a dedicated API endpoint for getting version information (instead of requesting much bigger `package.json`).

UI Demo:
![Screenshot from 2021-05-06 19-44-41](https://user-images.githubusercontent.com/35810911/117335889-276bde80-ae8b-11eb-8cec-657487c4a60f.png)
