### PR TITLE
Fix: HFUI props warnings

### DIFF
--- a/src/components/HFUI/HFUI.js
+++ b/src/components/HFUI/HFUI.js
@@ -58,13 +58,18 @@ const HFUI = ({
 }
 
 HFUI.propTypes = {
-  authToken: PropTypes.string.isRequired,
+  authToken: PropTypes.string,
+  currentPage: PropTypes.string,
   currentMode: PropTypes.string.isRequired,
   getSettings: PropTypes.func.isRequired,
   getFavoritePairs: PropTypes.func.isRequired,
   notificationsVisible: PropTypes.bool.isRequired,
   GAPageview: PropTypes.func.isRequired,
-  currentPage: PropTypes.string.isRequired,
+}
+
+HFUI.defaultProps = {
+  authToken: '',
+  currentPage: '',
 }
 
 export default HFUI


### PR DESCRIPTION
#### Task: 
- [UI: fix HFUI props warnings ](https://app.asana.com/0/1125859137800433/1200302286246223)

#### Description:
-  Added default props to fix these warnings on the initial app rendering:

<img width="818" alt="hfui-props-warn" src="https://user-images.githubusercontent.com/41899906/117462999-e097ea80-af57-11eb-803f-26e252aeb8af.png">
