### PR TITLE
Fix: input password icon alignment

### DIFF
--- a/src/pages/Authentication/style.scss
+++ b/src/pages/Authentication/style.scss
@@ -110,7 +110,7 @@
   .hfui-input,
   .hfui-button {
     text-transform: uppercase;
-    margin-top: 16px;
+    margin-top: 9px;
     border-radius: 4px;
   }
 

--- a/src/ui/Input/style.scss
+++ b/src/ui/Input/style.scss
@@ -1,6 +1,8 @@
 @import '../../variables.scss';
 
 .hfui-input {
+  display: flex;
+
   p {
     margin-bottom: 8px;
     font-size: 12px;
@@ -20,8 +22,7 @@
 }
 
 .field-icon {
-  float: right;
-  margin-top: -30px;
+  margin-top: -3px;
   position: relative;
   border: none;
   color: $green-color;


### PR DESCRIPTION
#### Description:
- Fixed input password icon alignment on the login page
- Task: https://app.asana.com/0/1125859137800433/1200332623388391

#### Before:
<img width="433" alt="icon-before" src="https://user-images.githubusercontent.com/41899906/118296746-fa03de00-b4e5-11eb-9711-e469a3a12002.png">

#### After:
<img width="414" alt="icon-after" src="https://user-images.githubusercontent.com/41899906/118296786-05efa000-b4e6-11eb-8871-af6934ee5fee.png">
