### PR TITLE
refactor: ufx-ui VirtualTable integration into atomic orders

### DIFF
--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
@@ -3,7 +3,7 @@ import React from 'react'
 export default (authToken, cancelOrder, gaCancelOrder) => [{
   label: 'Symbol',
   dataKey: 'symbol',
-  width: 120,
+  width: 145,
   cellRenderer: ({ rowData = {} }) => rowData.symbol,
 }, {
   label: 'Type',
@@ -13,15 +13,14 @@ export default (authToken, cancelOrder, gaCancelOrder) => [{
 }, {
   label: 'Amount',
   dataKey: 'amount',
-  width: 120,
-  cellRenderer: ({ rowData = {} }) => (rowData.amount < 0 // eslint-disable-line
-    ? <span className='hfui-red'>{rowData.amount}</span>
-    : <span className='hfui-green'>{rowData.amount}</span>
+  width: 100,
+  cellRenderer: ({ rowData = {} }) => ( // eslint-disable-line
+    <span className={rowData.amount < 0 ? 'hfui-red' : 'hfui-green'}>{rowData.amount}</span>
   ),
 }, {
   label: 'Price',
   dataKey: 'price',
-  width: 120,
+  width: 100,
   cellRenderer: ({ rowData = {} }) => rowData.price,
 }, {
   label: 'Status',

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.js
@@ -1,19 +1,26 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import _isEmpty from 'lodash/isEmpty'
+import { VirtualTable } from '@ufx-ui/core'
 
 import AtomicOrdersTableColumns from './AtomicOrdersTable.columns'
-import Table from '../../ui/Table'
 import './style.css'
 
 const AtomicOrdersTable = ({
   filteredAtomicOrders: orders, cancelOrder, authToken, gaCancelOrder,
 }) => (
-  <Table
-    data={orders}
-    columns={AtomicOrdersTableColumns(authToken, cancelOrder, gaCancelOrder)}
-    defaultSortBy='mts'
-    defaultSortDirection='ASC'
-  />
+  <div className='hfui-orderstable__wrapper'>
+    {_isEmpty(orders) ? (
+      <p className='empty'>No active atomic orders</p>
+    ) : (
+      <VirtualTable
+        data={orders}
+        columns={AtomicOrdersTableColumns(authToken, cancelOrder, gaCancelOrder)}
+        defaultSortBy='mts'
+        defaultSortDirection='ASC'
+      />
+    )}
+  </div>
 )
 
 AtomicOrdersTable.propTypes = {

--- a/src/components/AtomicOrdersTable/style.scss
+++ b/src/components/AtomicOrdersTable/style.scss
@@ -1,49 +1,21 @@
 @import '../../variables.scss';
 
 .hfui-orderstable__wrapper {
-  color: $grey-color;
-  padding: 8px 8px 0 8px;
-  overflow: hidden;
+  padding-bottom: 8px;
 
-  > p:first-child {
-    font-size: 12px;
-    margin-bottom: 2px;
+  .empty {
+    margin-top: 10px;
+    font-size: 16px;
+    text-align: center;
   }
 
-  .hfui-orderstable__header {
-    border-bottom: 1px solid $grey-color;
-    padding-bottom: 2px;
-    margin-bottom: 2px;
-
-    p {
-      text-transform: uppercase;
-    }
-  }
-
-  li {
-    display: flex;
-    flex-direction: row;
-
-    p {
-      font-size: 12px;
-      line-height: 16px;
-      width: 100%;
+  .icons-cell > * {
+    margin-right: 8px;
+    font-size: 16px;
+  
+    &:hover {
+      cursor: pointer;
       color: $text-color;
-
-      margin-right: 32px;
-
-      &:last-child {
-        text-align: right;
-        margin-right: 0;
-      }
-    }
-
-    &.buy .hfui-orderstable__amount {
-      color: $green-color;
-    }
-
-    &.sell .hfui-orderstable__amount {
-      color: $red-color;
     }
   }
 }


### PR DESCRIPTION
ASANA Ticket: [Atomic Orders integration](https://app.asana.com/0/1125859137800433/1200183047626386/f)

Description:
    - Atomic orders implementation was replaced with ufx-ui TableVirtual component.
    - Refactored atomic order into simpler, functional component.

UI Demonstration:
![Screenshot from 2021-05-19 13-41-29](https://user-images.githubusercontent.com/35810911/118799882-cb438a00-b88e-11eb-9dea-8f9e34b27441.png)
![Screenshot from 2021-05-19 13-39-15](https://user-images.githubusercontent.com/35810911/118799892-ce3e7a80-b88e-11eb-812f-0f114db8b6a4.png)

