### PR TITLE
fix: send pause event to server

### DIFF
--- a/src/components/HFUI/HFUI.container.js
+++ b/src/components/HFUI/HFUI.container.js
@@ -31,6 +31,9 @@ const mapDispatchToProps = dispatch => ({
       mode,
     ]))
   },
+  onUnload: (authToken, mode) => {
+    dispatch(WSActions.onUnload(authToken, mode))
+  },
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(HFUI)

--- a/src/components/HFUI/HFUI.js
+++ b/src/components/HFUI/HFUI.js
@@ -16,14 +16,22 @@ import NotificationsSidebar from '../NotificationsSidebar'
 import './style.css'
 
 const HFUI = ({
-  authToken,
-  getSettings,
-  notificationsVisible,
-  getFavoritePairs,
-  currentMode,
-  GAPageview,
-  currentPage,
+  authToken, getSettings, notificationsVisible, getFavoritePairs, currentMode, GAPageview, currentPage, onUnload,
 }) => {
+  const unloadHandler = () => {
+    if (authToken !== null) {
+      onUnload(authToken, currentMode)
+    }
+  }
+
+  useEffect(() => {
+    window.removeEventListener('beforeunload', unloadHandler)
+    window.addEventListener('beforeunload', unloadHandler)
+    return () => {
+      window.removeEventListener('beforeunload', unloadHandler)
+    }
+  }, [authToken, currentMode])
+
   useEffect(() => {
     GAPageview(currentPage)
   }, [currentPage])
@@ -63,6 +71,7 @@ HFUI.propTypes = {
   currentMode: PropTypes.string.isRequired,
   getSettings: PropTypes.func.isRequired,
   getFavoritePairs: PropTypes.func.isRequired,
+  onUnload: PropTypes.func.isRequired,
   notificationsVisible: PropTypes.bool.isRequired,
   GAPageview: PropTypes.func.isRequired,
 }

--- a/src/redux/actions/ws.js
+++ b/src/redux/actions/ws.js
@@ -292,4 +292,5 @@ export default {
   initAuth: password => send(['auth.init', password, 'main']),
   auth: (password, mode) => send(['auth.submit', password, mode]),
   resetAuth: () => send(['auth.reset']),
+  onUnload: (authToken, mode) => send(['algo_order.pause', authToken, mode]),
 }


### PR DESCRIPTION
ASANA Ticket: [UI: app exit - send pause event to server](https://app.asana.com/0/1125859137800433/1200341518248846/f)

The `unloadHandler` listens to `beforeunload` event and triggers `onUnload` method before the app is closed.