### PR TITLE
fix: false positive on reconnect modal

### DIFF
--- a/src/redux/sagas/ws/index.js
+++ b/src/redux/sagas/ws/index.js
@@ -3,6 +3,7 @@ import t from '../../constants/ws'
 
 import connectionWorker from './worker_connection'
 import messageQueueWorker from './worker_message_queue'
+import pingWorker from './worker_ping_connection'
 import { updateWorker } from './worker_flush_exchange_data'
 
 import onConnected from './on_connected'
@@ -32,4 +33,5 @@ export default function* () {
 
   yield fork(updateWorker)
   yield fork(connectionWorker)
+  yield fork(pingWorker)
 }

--- a/src/redux/sagas/ws/worker_ping_connection.js
+++ b/src/redux/sagas/ws/worker_ping_connection.js
@@ -1,0 +1,27 @@
+import { put, delay, select } from 'redux-saga/effects'
+import _filter from 'lodash/filter'
+import _includes from 'lodash/includes'
+import _keys from 'lodash/keys'
+
+import WSActions from '../../actions/ws'
+import { getSockets } from '../../selectors/ws'
+
+import WSTypes from '../../constants/ws'
+
+const URLS_TO_IGNORE = [WSTypes.ALIAS_API_SERVER, WSTypes.ALIAS_DATA_SERVER]
+const PING_CONNECTION_EVERY_MS = 30 * 1000
+const data = { event: 'ping' }
+
+export default function* () {
+  while (true) {
+    const sockets = yield select(getSockets)
+    const keys = _filter(_keys(sockets), alias => !_includes(URLS_TO_IGNORE, alias))
+
+    for (let i = 0; i < keys.length; ++i) {
+      const alias = keys[i]
+      yield put(WSActions.send({ data, alias }))
+    }
+
+    yield delay(PING_CONNECTION_EVERY_MS)
+  }
+}


### PR DESCRIPTION
ASANA Ticket: [Reconnect modal false positive](https://app.asana.com/0/1125859137800433/1200377606276626/f)

Description: Bitfinex Websocket public API does require pinging it regularly if there are no other messages being sent, otherwise the connection will be dropped which causes a false positive 'Reconnect Modal'.
This pull request adds a worker, which will ping a websocket connections every 30 seconds except those which do not require it (API and data servers).

UI Demonstration:
![Screenshot from 2021-05-25 17-05-33](https://user-images.githubusercontent.com/35810911/119514239-5f689200-bd64-11eb-8c67-7c9a8aa3e775.png)
