### PR TITLE
fixed: HistoricalForm: changed startDate initial format

### DIFF
--- a/src/components/Backtester/forms/HistoricalForm.js
+++ b/src/components/Backtester/forms/HistoricalForm.js
@@ -121,7 +121,7 @@ export default class HistoricalForm extends React.PureComponent {
       selectedMarket,
       selectedTimeFrame,
     } = this.defaultFormState(formState)
-    console.log('startDate', startDate, 'endDate', endDate)
+
     return (
       <div className='hfui-backtester__executionform'>
         <div className='hfui-backtester_row'>

--- a/src/components/Backtester/forms/HistoricalForm.js
+++ b/src/components/Backtester/forms/HistoricalForm.js
@@ -76,7 +76,7 @@ export default class HistoricalForm extends React.PureComponent {
     const { markets } = this.props
 
     return {
-      startDate: new Date() - ONE_DAY,
+      startDate: new Date(Date.now() - ONE_DAY),
       endDate: new Date(Date.now() - (ONE_MIN * 15)),
       selectedTimeFrame: '15m',
       selectedMarket: markets[0],
@@ -121,7 +121,7 @@ export default class HistoricalForm extends React.PureComponent {
       selectedMarket,
       selectedTimeFrame,
     } = this.defaultFormState(formState)
-
+    console.log('startDate', startDate, 'endDate', endDate)
     return (
       <div className='hfui-backtester__executionform'>
         <div className='hfui-backtester_row'>

--- a/src/components/OrderForm/FieldComponents/input.date.js
+++ b/src/components/OrderForm/FieldComponents/input.date.js
@@ -4,12 +4,11 @@ import PropTypes from 'prop-types'
 
 import { renderString, CONVERT_LABELS_TO_PLACEHOLDERS } from '../OrderForm.helpers'
 
-const DateInput = memo(({
+const DateInput = ({
   value, minDate, maxDate, onChange, def, renderData, validationError,
 }) => {
   const { label, minDate: MIN_DATE } = def
   const renderedLabel = renderString(label, renderData)
-
   return (
     <div className='hfui-orderform__input fullWidth hfui-input'>
       <DatePicker
@@ -43,7 +42,7 @@ const DateInput = memo(({
       )}
     </div>
   )
-})
+}
 
 DateInput.processValue = v => +v
 
@@ -56,8 +55,6 @@ DateInput.validateValue = v => {
 
   return false
 }
-
-DateInput.displayName = 'DateInput'
 
 DateInput.propTypes = {
   def: PropTypes.objectOf(PropTypes.oneOfType([
@@ -84,4 +81,4 @@ DateInput.defaultProps = {
   def: {},
 }
 
-export default DateInput
+export default memo(DateInput)


### PR DESCRIPTION
![Снимок экрана от 2021-05-25 18-20-09](https://user-images.githubusercontent.com/81973123/119525444-2db4f280-bd87-11eb-9f8d-7878e9bbbc71.png)
Resolved issue with initial startDate value in HistoricalForm component. Children component requires Date format value but taken number format (timestamp) value