### PR TITLE
improvement: OrderHistory empty message

### DIFF
--- a/src/components/OrderHistory/OrderHistory.container.js
+++ b/src/components/OrderHistory/OrderHistory.container.js
@@ -1,0 +1,8 @@
+import { connect } from 'react-redux'
+import OrderHistory from './OrderHistory'
+
+const mapStateToProps = (state = {}) => ({
+  orders: state.ws.orderHistory?.orders,
+})
+
+export default connect(mapStateToProps)(OrderHistory)

--- a/src/components/OrderHistory/OrderHistory.js
+++ b/src/components/OrderHistory/OrderHistory.js
@@ -1,9 +1,10 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import _get from 'lodash/get'
+import _isEmpty from 'lodash/isEmpty'
 import {
   OrderHistory as UfxOrderHistory, ORDER_HISTORY_KEYS, PrettyValue, FullDate,
 } from '@ufx-ui/core'
-import { useSelector } from 'react-redux'
 import Panel from '../../ui/Panel'
 import { symbolToLabel, getPriceFromStatus, getFormatedStatus } from './OrderHistory.helpers'
 import './style.css'
@@ -93,26 +94,37 @@ export const ROW_MAPPING = {
   },
 }
 
-export default function OrderHistory(props) {
-  const {
-    // eslint-disable-next-line react/prop-types
-    onRemove, dark,
-  } = props
-
-  const orders = useSelector(state => state.ws.orderHistory.orders)
-
-  return (
-    <Panel
-      label='ORDER HISTORY'
-      onRemove={onRemove}
-      dark={dark}
-      darkHeader={dark}
-    >
+const OrderHistory = ({
+  onRemove, dark, orders,
+}) => (
+  <Panel
+    label='ORDER HISTORY'
+    onRemove={onRemove}
+    dark={dark}
+    darkHeader={dark}
+  >
+    {_isEmpty(orders) ? (
+      <p className='empty'>Order history is empty</p>
+    ) : (
       <UfxOrderHistory
         orders={orders}
         rowMapping={ROW_MAPPING}
         isMobileLayout={false}
       />
-    </Panel>
-  )
+    )}
+  </Panel>
+)
+
+OrderHistory.propTypes = {
+  orders: PropTypes.arrayOf(PropTypes.object),
+  dark: PropTypes.bool,
+  onRemove: PropTypes.func,
 }
+
+OrderHistory.defaultProps = {
+  onRemove: () => {},
+  dark: true,
+  orders: [],
+}
+
+export default OrderHistory

--- a/src/components/OrderHistory/index.js
+++ b/src/components/OrderHistory/index.js
@@ -1,3 +1,3 @@
-import OrderHistory from './OrderHistory'
+import OrderHistory from './OrderHistory.container'
 
 export default OrderHistory

--- a/src/pages/MarketData/MarketData.container.js
+++ b/src/pages/MarketData/MarketData.container.js
@@ -1,11 +1,7 @@
 import { connect } from 'react-redux'
-import {
-  getLayouts, getActiveMarket, getFirstLogin,
-  getGuideStatusForPage,
-} from '../../redux/selectors/ui'
+import { getFirstLogin, getGuideStatusForPage } from '../../redux/selectors/ui'
 import { MARKET_PAGE } from '../../redux/constants/ui'
 import UIActions from '../../redux/actions/ui'
-
 import MarketData from './MarketData'
 
 const mapStateToProps = (state = {}) => ({


### PR DESCRIPTION
ASANA Ticket: [Order history table when no elements should have bigger fonts and headers removed task](https://app.asana.com/0/1125859137800433/1200383864348742/f)

Description:
 - improved empty message in order history
 - refactored components, added prop validation
 - moved redux logic into separated container
 - fixed MarketData unused variables warning

UI Demo:
![Screenshot from 2021-05-27 13-08-29](https://user-images.githubusercontent.com/35810911/119808742-f2740a00-bed3-11eb-85d3-0316939b3bfe.png)
![Screenshot from 2021-05-27 13-07-41](https://user-images.githubusercontent.com/35810911/119808736-f1db7380-bed3-11eb-832d-c725553e4bf0.png)
