### PR TITLE
fix: orderform always visible execute orders

### DIFF
--- a/src/components/Layout/style.scss
+++ b/src/components/Layout/style.scss
@@ -27,3 +27,7 @@
 .layout__footer {
   flex-shrink: 0;
 }
+
+.layout__footer {
+  padding-top: 30px;
+}

--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -372,7 +372,7 @@ class OrderForm extends React.Component {
               </div>
             )}
 
-            {!currentLayout && (
+            {!currentLayout && apiClientConfigured && (
               <div key='order-form-menu' className='hfui-orderform__overlay-wrapper'>
                 <OrderFormMenu
                   atomicOrderTypes={atomicOrderTypes}

--- a/src/components/OrderForm/style.scss
+++ b/src/components/OrderForm/style.scss
@@ -2,6 +2,7 @@
 
 .hfui-orderform__wrapper {
   height: 100%;
+  padding-right: 7px;
 
   .react-datepicker-popper {
     left: -2px;


### PR DESCRIPTION
ASANA Ticket: [Execute orders will be visible under set API keys](https://app.asana.com/0/1125859137800433/1200421887481897/f)

UI Demo:
![Screenshot from 2021-06-03 19-30-08](https://user-images.githubusercontent.com/35810911/120679677-f9c58580-c488-11eb-9895-79d5a7cf6d00.png)
