### PR TITLE
improvement: empty balance message; table prices localisation

### DIFF
--- a/src/components/BalancesTable/BalancesTable.js
+++ b/src/components/BalancesTable/BalancesTable.js
@@ -1,8 +1,9 @@
 import React, { memo } from 'react'
 import PropTypes from 'prop-types'
+import _isEmpty from 'lodash/isEmpty'
+import { VirtualTable } from '@ufx-ui/core'
 
 import BalancesTableColumns from './BalancesTable.columns'
-import Table from '../../ui/Table'
 
 const BalancesTable = ({
   renderedInTradingState, filteredBalances, balances, hideZeroBalances,
@@ -12,11 +13,17 @@ const BalancesTable = ({
     ? data.filter(b => +b.balance > 0)
     : data
 
+  if (_isEmpty(filtered)) {
+    return (
+      <p className='empty'>No balances available</p>
+    )
+  }
+
   return (
-    <Table
+    <VirtualTable
       data={filtered}
       columns={BalancesTableColumns()}
-      defaultSortBy='mts'
+      defaultSortBy='context'
       defaultSortDirection='ASC'
     />
   )

--- a/src/util/ui.js
+++ b/src/util/ui.js
@@ -6,8 +6,19 @@ import _toArray from 'lodash/toArray'
 import _toString from 'lodash/toString'
 import _reverse from 'lodash/reverse'
 
-export const processBalance = (value) => {
-  const str = _toString(value)
+// takes a number as input and returns a localised version with semicolons in it
+// e.g. '123456789.445566' -> '123,456,789.445566'
+const localiseNumber = (x) => {
+  return x.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')
+}
+
+export const processBalance = (value, localise = true) => {
+  let str = _toString(value)
+
+  if (localise) {
+    str = localiseNumber(str)
+  }
+
   if (!_toString(_split(value, '.')[1])) {
     return str
   }


### PR DESCRIPTION
ASANA Ticket: [Add message for no balance (and remove column header)](https://app.asana.com/0/1125859137800433/1200426227532519/f)

Description:
 - added message to be shown in case if balances table is empty.
 - added method to localise numbers (add semicolons in them).

UI Demo:
![Screenshot from 2021-06-04 16-42-09](https://user-images.githubusercontent.com/35810911/120810970-099da200-c53b-11eb-85b9-41e202b4a618.png)
![Screenshot from 2021-06-04 16-42-39](https://user-images.githubusercontent.com/35810911/120810899-f985c280-c53a-11eb-8b61-c6d91d8ab186.png)
