### PR TITLE
improvement: table bar/circle markers based on component's width

### DIFF
--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.columns.js
@@ -1,11 +1,11 @@
 import React from 'react'
 
-export default (authToken, cancelOrder, gaCancelOrder) => [{
+export default (authToken, cancelOrder, gaCancelOrder, { width }) => [{
   label: '',
   dataKey: '',
   width: 15,
   cellRenderer: ({ rowData = {} }) => ( // eslint-disable-line
-    <div className={`row-marker ${rowData.amount < 0 ? 'red' : 'green'}`} />
+    <div className={`row-marker ${rowData.amount < 0 ? 'red' : 'green'} ${width < 700 ? 'stick' : ''} ${width < 450 ? 'stick2' : ''}`} />
   ),
   disableSort: true,
 }, {

--- a/src/components/AtomicOrdersTable/AtomicOrdersTable.js
+++ b/src/components/AtomicOrdersTable/AtomicOrdersTable.js
@@ -3,25 +3,30 @@ import PropTypes from 'prop-types'
 import _isEmpty from 'lodash/isEmpty'
 import { VirtualTable } from '@ufx-ui/core'
 
+import useSize from '../../hooks/useSize'
 import AtomicOrdersTableColumns from './AtomicOrdersTable.columns'
 import './style.css'
 
 const AtomicOrdersTable = ({
   filteredAtomicOrders: orders, cancelOrder, authToken, gaCancelOrder,
-}) => (
-  <div className='hfui-orderstable__wrapper'>
-    {_isEmpty(orders) ? (
-      <p className='empty'>No active atomic orders</p>
-    ) : (
-      <VirtualTable
-        data={orders}
-        columns={AtomicOrdersTableColumns(authToken, cancelOrder, gaCancelOrder)}
-        defaultSortBy='id'
-        defaultSortDirection='ASC'
-      />
-    )}
-  </div>
-)
+}) => {
+  const [ref, size] = useSize()
+
+  return (
+    <div ref={ref} className='hfui-orderstable__wrapper'>
+      {_isEmpty(orders) ? (
+        <p className='empty'>No active atomic orders</p>
+      ) : (
+        <VirtualTable
+          data={orders}
+          columns={AtomicOrdersTableColumns(authToken, cancelOrder, gaCancelOrder, size)}
+          defaultSortBy='id'
+          defaultSortDirection='ASC'
+        />
+      )}
+    </div>
+  )
+}
 
 AtomicOrdersTable.propTypes = {
   authToken: PropTypes.string.isRequired,

--- a/src/components/AtomicOrdersTable/style.scss
+++ b/src/components/AtomicOrdersTable/style.scss
@@ -17,19 +17,4 @@
       color: $text-color;
     }
   }
-
-  .row-marker {
-    background: transparent;
-    border-radius: 50%;
-    width: 12px;
-    height: 12px;
-
-    &.green {
-      background-color: $green-color;
-    }
-
-    &.red {
-      background-color: $red-color;
-    }
-  }
 }

--- a/src/components/OrderHistory/OrderHistory.js
+++ b/src/components/OrderHistory/OrderHistory.js
@@ -25,7 +25,7 @@ const {
   STATUS,
 } = ORDER_HISTORY_KEYS
 
-export const rowMapper = ({ width }) => ({
+export const ROW_MAPPING = {
   [ID]: {
     hidden: true,
   },
@@ -41,9 +41,6 @@ export const rowMapper = ({ width }) => ({
   [ICON]: {
     index: 0,
     truncate: true,
-    renderer: ({ data = {} }) => ( // eslint-disable-line
-      <div className={`row-marker ${data.originalAmount < 0 ? 'red' : 'green'} ${width < 700 ? 'stick stick2' : ''}`} />
-    ),
   },
   [PAIR]: {
     index: 1,
@@ -96,12 +93,12 @@ export const rowMapper = ({ width }) => ({
       return <FullDate ts={_get(data, 'created')} />
     },
   },
-})
+}
 
 const OrderHistory = ({
   onRemove, dark, orders,
 }) => {
-  const [ref, size] = useSize()
+  const [ref, { width }] = useSize()
 
   return (
     <Panel
@@ -116,8 +113,8 @@ const OrderHistory = ({
       ) : (
         <UfxOrderHistory
           orders={orders}
-          rowMapping={rowMapper(size)}
-          isMobileLayout={false}
+          rowMapping={ROW_MAPPING}
+          isMobileLayout={width < 700}
         />
       )}
     </Panel>

--- a/src/components/OrderHistory/OrderHistory.js
+++ b/src/components/OrderHistory/OrderHistory.js
@@ -6,6 +6,7 @@ import {
   OrderHistory as UfxOrderHistory, ORDER_HISTORY_KEYS, PrettyValue, FullDate,
 } from '@ufx-ui/core'
 import Panel from '../../ui/Panel'
+import useSize from '../../hooks/useSize'
 import { symbolToLabel, getPriceFromStatus, getFormatedStatus } from './OrderHistory.helpers'
 import './style.css'
 
@@ -24,7 +25,7 @@ const {
   STATUS,
 } = ORDER_HISTORY_KEYS
 
-export const ROW_MAPPING = {
+export const rowMapper = ({ width }) => ({
   [ID]: {
     hidden: true,
   },
@@ -40,6 +41,9 @@ export const ROW_MAPPING = {
   [ICON]: {
     index: 0,
     truncate: true,
+    renderer: ({ data = {} }) => ( // eslint-disable-line
+      <div className={`row-marker ${data.originalAmount < 0 ? 'red' : 'green'} ${width < 700 ? 'stick stick2' : ''}`} />
+    ),
   },
   [PAIR]: {
     index: 1,
@@ -92,28 +96,33 @@ export const ROW_MAPPING = {
       return <FullDate ts={_get(data, 'created')} />
     },
   },
-}
+})
 
 const OrderHistory = ({
   onRemove, dark, orders,
-}) => (
-  <Panel
-    label='Order History'
-    onRemove={onRemove}
-    dark={dark}
-    darkHeader={dark}
-  >
-    {_isEmpty(orders) ? (
-      <p className='empty'>Order history is empty</p>
-    ) : (
-      <UfxOrderHistory
-        orders={orders}
-        rowMapping={ROW_MAPPING}
-        isMobileLayout={false}
-      />
-    )}
-  </Panel>
-)
+}) => {
+  const [ref, size] = useSize()
+
+  return (
+    <Panel
+      label='Order History'
+      onRemove={onRemove}
+      dark={dark}
+      darkHeader={dark}
+      innerRef={ref}
+    >
+      {_isEmpty(orders) ? (
+        <p className='empty'>Order history is empty</p>
+      ) : (
+        <UfxOrderHistory
+          orders={orders}
+          rowMapping={rowMapper(size)}
+          isMobileLayout={false}
+        />
+      )}
+    </Panel>
+  )
+}
 
 OrderHistory.propTypes = {
   orders: PropTypes.arrayOf(PropTypes.object),
@@ -122,7 +131,7 @@ OrderHistory.propTypes = {
 }
 
 OrderHistory.defaultProps = {
-  onRemove: () => {},
+  onRemove: () => { },
   dark: true,
   orders: [],
 }

--- a/src/hooks/useSize.js
+++ b/src/hooks/useSize.js
@@ -1,0 +1,25 @@
+/* eslint-disable consistent-return */
+import { useEffect, useRef, useState } from 'react'
+import _get from 'lodash/get'
+
+export default () => {
+  const [size, setSize] = useState({})
+  const ref = useRef(null)
+  useEffect(() => {
+    const DOMnode = ref.current
+    if (!DOMnode) {
+      return
+    }
+    const resizeObserver = new ResizeObserver((entries) => {
+      setSize({
+        width: _get(entries, '0.contentRect.width', 0),
+        height: _get(entries, '0.contentRect.height', 0),
+      })
+    })
+    resizeObserver.observe(DOMnode)
+    return () => {
+      resizeObserver.unobserve(DOMnode)
+    }
+  }, [])
+  return [ref, size]
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -256,6 +256,33 @@ a:visited {
   text-align: center;
 }
 
+// OrderHistory & Atomic Orders table marker icon
+.row-marker {
+  background: transparent;
+  border-radius: 50%;
+  width: 12px;
+  height: 12px;
+
+  &.stick {
+    width: 2px;
+    height: 12px;
+    border-radius: 0;
+    margin-left: 5px;
+  }
+
+  &.stick2 {
+    margin-left: 0;
+  }
+
+  &.green {
+    background-color: $green-color;
+  }
+
+  &.red {
+    background-color: $red-color;
+  }
+}
+
 [class*="icon-"]:before {
   font-weight: 600 !important;
 }

--- a/src/ui/Panel/index.js
+++ b/src/ui/Panel/index.js
@@ -46,6 +46,7 @@ export default class Panel extends React.Component {
       preHeaderComponents,
       dropdown,
       forcedTab,
+      innerRef,
     } = this.props
     const tabs = React.Children.toArray(children).filter(c => c && c.props.tabtitle)
     const { selectedTab = forcedTab.length ? this.getForcedTab(forcedTab, tabs) : tabs[0] } = this.state
@@ -56,6 +57,7 @@ export default class Panel extends React.Component {
           'dark-header': darkHeader,
           dark,
         })}
+        ref={innerRef}
       >
         <div
           className={ClassNames('hfui-panel__header', {
@@ -190,6 +192,10 @@ Panel.propTypes = {
   preHeaderComponents: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
   forcedTab: PropTypes.string,
   dropdown: PropTypes.node,
+  innerRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any }),
+  ]),
 }
 
 Panel.defaultProps = {
@@ -216,4 +222,5 @@ Panel.defaultProps = {
   preHeaderComponents: null,
   forcedTab: '',
   dropdown: null,
+  innerRef: null,
 }


### PR DESCRIPTION
ASANA Ticket: [Add bars instead of circles on orders and order history for shorter width](https://app.asana.com/0/1125859137800433/1200426041616722/f)

Description: In this PR I used Jason's [useSize hook](https://github.com/bitfinexcom/bfx-hf-ui/pull/477) to implement switching from circles into bars and vice versa on OrderHistory and AtomicOrders table based on component width.

UI Demonstration:

https://user-images.githubusercontent.com/35810911/122222321-acdaa980-cea1-11eb-8811-2ef1793e57f6.mp4

