### PR TITLE
(improvement) UI of submit api keys

### DIFF
--- a/src/components/OrderForm/Modals/UnconfiguredModal/UnconfiguredModal.js
+++ b/src/components/OrderForm/Modals/UnconfiguredModal/UnconfiguredModal.js
@@ -6,16 +6,16 @@ import OrderFormModal from '../../OrderFormModal'
 const UnconfiguredModal = ({ onClick, isPaperTrading }) => (
   <OrderFormModal
     title='NOT CONFIGURED'
-    titleColor='#f05359'
     icon='icon-api'
     onClick={onClick}
-    content={[
-      <p key='a' className='underline'>
+    content={(
+      // eslint-disable-next-line jsx-a11y/anchor-is-valid
+      <a className='submit-keys'>
         Submit
         {isPaperTrading ? ' Paper Trading ' : ' '}
         API keys
-      </p>,
-    ]}
+      </a>
+    )}
   />
 )
 

--- a/src/components/OrderForm/style.scss
+++ b/src/components/OrderForm/style.scss
@@ -442,7 +442,6 @@
   position: absolute;
   top: 0;
   left: 0;
-  background: $background-color;
   width: 100%;
   height: calc(100% - 10px);
   user-select: none;
@@ -455,8 +454,14 @@
     font-weight: 500;
   }
 
-  .underline {
-    text-decoration: underline;
+  .submit-keys {
+    color: $primary-color-800;
+    font-weight: 700;
+
+    &:hover {
+      color: $primary-color-900;
+      text-decoration: underline;
+    }
   }
 
   .notice {


### PR DESCRIPTION
This makes it match more with the rest of the theme.

Before:
![image](https://user-images.githubusercontent.com/13964126/123137019-9c5b9d80-d464-11eb-8899-4ab0385e94b3.png)


After:
![image](https://user-images.githubusercontent.com/13964126/123136977-92d23580-d464-11eb-96ac-74e760f3c482.png)
