### PR TITLE
fix: process data before it's validation

### DIFF
--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -249,7 +249,6 @@ class OrderForm extends React.Component {
     const {
       currentMarket, currentLayout, fieldData, context,
     } = this.state
-    let errors
 
     const { id } = currentLayout
     const data = processFieldData({
@@ -257,35 +256,7 @@ class OrderForm extends React.Component {
       action: 'submit',
       fieldData,
     })
-
-    switch (currentLayout.id) {
-      case Iceberg.id:
-        errors = Iceberg.meta.validateParams(data)
-        break
-
-      case TWAP.id:
-        errors = TWAP.meta.validateParams(data)
-        break
-
-      case AccumulateDistribute.id:
-        errors = AccumulateDistribute.meta.validateParams(data)
-        break
-
-      case PingPong.id:
-        errors = PingPong.meta.validateParams(data)
-        break
-
-      case MACrossover.id:
-        errors = MACrossover.meta.validateParams(data)
-        break
-
-      case OCOCO.id:
-        errors = OCOCO.meta.validateParams(data)
-        break
-
-      default:
-        debug('unknown layout %s', currentLayout.id)
-    }
+    const errors = this.validateAOData(data)
 
     if (_isEmpty(errors)) {
       gaSubmitAO()
@@ -306,6 +277,54 @@ class OrderForm extends React.Component {
         },
       }))
     }
+  }
+
+  validateAOData(data) {
+    const { currentLayout } = this.state
+    let errors = {}
+
+    switch (currentLayout.id) {
+      case Iceberg.id: {
+        const processedData = Iceberg.meta.processParams(data)
+        errors = Iceberg.meta.validateParams(processedData)
+        break
+      }
+
+      case TWAP.id: {
+        const processedData = TWAP.meta.processParams(data)
+        errors = TWAP.meta.validateParams(processedData)
+        break
+      }
+
+      case AccumulateDistribute.id: {
+        const processedData = AccumulateDistribute.meta.processParams(data)
+        errors = AccumulateDistribute.meta.validateParams(processedData)
+        break
+      }
+
+      case PingPong.id: {
+        const processedData = PingPong.meta.processParams(data)
+        errors = PingPong.meta.validateParams(processedData)
+        break
+      }
+
+      case MACrossover.id: {
+        const processedData = MACrossover.meta.processParams(data)
+        errors = MACrossover.meta.validateParams(processedData)
+        break
+      }
+
+      case OCOCO.id: {
+        const processedData = OCOCO.meta.processParams(data)
+        errors = OCOCO.meta.validateParams(processedData)
+        break
+      }
+
+      default:
+        debug('unknown layout %s', currentLayout.id)
+    }
+
+    return errors
   }
 
   deferSaveState() {


### PR DESCRIPTION
ASANA Ticket: [OrderForm data should be processed before trying to validate it](https://app.asana.com/0/1125859137800433/1200516437683803/f)

Description: `validateParams` method expects to receive data processed via the `processParams` method, otherwise it will cause false positive errors when trying to submit some algo orders (Accumulate/Distribute, for example).