### PR TITLE
(fix) Saved layout compatibility

### DIFF
--- a/src/components/ChartPanel/ChartPanel.js
+++ b/src/components/ChartPanel/ChartPanel.js
@@ -45,7 +45,7 @@ const ChartPanel = ({
   return (
     <Panel
       dark={dark}
-      label={label || `Chart - ${currentMarket.uiID}`}
+      label={label || 'Chart'}
       darkHeader={dark}
       onRemove={onRemove}
       moveable={moveable}

--- a/src/components/ExchangeInfoBar/style.scss
+++ b/src/components/ExchangeInfoBar/style.scss
@@ -168,6 +168,10 @@
   color: $light-color-900;
 }
 
+.react-switch-bg {
+  opacity: .3;
+}
+
 .react-switch-bg svg * {
   display: none;
 }

--- a/src/redux/reducers/ui/index.js
+++ b/src/redux/reducers/ui/index.js
@@ -81,7 +81,6 @@ function getInitialState() {
       _values(storedLayouts),
       layout => !_isUndefined(layout.savedAt),
     )
-    console.log('TCL: getInitialState -> isNewFormat', isNewFormat)
 
     // transform old format to new format for compatibility
     const nextFormatLayouts = isNewFormat ? storedLayouts : _reduce(


### PR DESCRIPTION
Fixes issue reported by Robert https://bitfinex.slack.com/archives/CKKLH6HA9/p1624538940331100

There's a format change in the layouts, this PR will transform the old format to the new. It will keep the old default layouts saved under the old key (without " Layout" suffix) as they may have been changed by the user.
![image](https://user-images.githubusercontent.com/13964126/123286428-f4ef7100-d51e-11eb-9250-81f58d3279af.png)
