### PR TITLE
(fix) Redux provider error for linked packages

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -270,6 +270,7 @@ module.exports = function (webpackEnv) {
         // Support React Native Web
         // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
         'react-native': 'react-native-web',
+        'react-redux': require.resolve('react-redux'),
       },
       plugins: [
         // Adds support for installing with Plug'n'Play, leading to faster installs and adding


### PR DESCRIPTION
This fixes @ufx-ui Provider errors when using npm link.

Reference:
https://github.com/reduxjs/react-redux/issues/1489