### PR TITLE
fix: OrderForm not working input

### DIFF
--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -174,9 +174,6 @@ class OrderForm extends React.Component {
     }) => {
       const { fields = {} } = currentLayout
       const field = fields[fieldName] || {}
-      if (field.disabled) {
-        return null
-      }
       const { component } = field
       const C = COMPONENTS_FOR_ID[component]
       let processedValue = value

--- a/src/components/OrderForm/OrderForm.js
+++ b/src/components/OrderForm/OrderForm.js
@@ -3,6 +3,7 @@ import { Icon } from 'react-fa'
 import _isEqual from 'lodash/isEqual'
 import _isEmpty from 'lodash/isEmpty'
 import _isString from 'lodash/isString'
+import _isBoolean from 'lodash/isBoolean'
 import _map from 'lodash/map'
 import _trim from 'lodash/trim'
 import PropTypes from 'prop-types'
@@ -174,6 +175,12 @@ class OrderForm extends React.Component {
     }) => {
       const { fields = {} } = currentLayout
       const field = fields[fieldName] || {}
+      const { disabled } = field
+
+      if (_isBoolean(disabled) && disabled) {
+        return null
+      }
+
       const { component } = field
       const C = COMPONENTS_FOR_ID[component]
       let processedValue = value


### PR DESCRIPTION
Description: `onFieldChange` had a condition where it checked whether the field entered was disabled.
It was useless for 2 reasons:
 - the disabled state is already verified in the inputs themselves via `verifyConditionsMet` helper
 - `onFieldChange` treated `disabled` param as `boolean`, not as `object` so it always returned `true` when the `disabled` param was present in `field` object

UI Demo:
![Screenshot from 2021-06-28 15-31-37](https://user-images.githubusercontent.com/35810911/123636796-cdddbb80-d80c-11eb-9cb6-7e040d7a566d.png)
