### PR TITLE
(fix) LocaliseNumber: compatibility with safari

### DIFF
--- a/src/util/ui.js
+++ b/src/util/ui.js
@@ -8,9 +8,7 @@ import _reverse from 'lodash/reverse'
 
 // takes a number as input and returns a localised version with semicolons in it
 // e.g. '123456789.445566' -> '123,456,789.445566'
-export const localiseNumber = (x) => {
-  return _toString(x).replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')
-}
+export const localiseNumber = (x) => x.toLocaleString('en-US')
 
 export const processBalance = (value, localise = true) => {
   let str = _toString(value)


### PR DESCRIPTION
ticket - https://app.asana.com/0/1200372033300327/1200534517432943

Changed localiseNumber fn, because Safari doesn't support lookbehind regexp (https://caniuse.com/js-regexp-lookbehind)