### PR TITLE
improvement: Strategy Editor label limitation

### DIFF
--- a/src/components/CreateNewStrategyModal/CreateNewStrategyModal.js
+++ b/src/components/CreateNewStrategyModal/CreateNewStrategyModal.js
@@ -11,6 +11,8 @@ import Dropdown from '../../ui/Dropdown'
 
 import './style.css'
 
+const MAX_LABEL_LENGTH = 150
+
 const CreateNewStrategyModal = ({
   onSubmit, onClose, gaCreateStrategy, isOpen,
 }) => {
@@ -26,8 +28,8 @@ const CreateNewStrategyModal = ({
       return
     }
 
-    if (labelSize > 150) {
-      setError(`Strategy name is too long (${labelSize}/150 characters)`)
+    if (labelSize > MAX_LABEL_LENGTH) {
+      setError(`Strategy name is too long (${labelSize}/${MAX_LABEL_LENGTH} characters)`)
       return
     }
 

--- a/src/components/CreateNewStrategyModal/CreateNewStrategyModal.js
+++ b/src/components/CreateNewStrategyModal/CreateNewStrategyModal.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import _isEmpty from 'lodash/isEmpty'
+import _size from 'lodash/size'
 import PropTypes from 'prop-types'
 
 import Templates from '../StrategyEditor/templates'
@@ -18,10 +19,18 @@ const CreateNewStrategyModal = ({
   const [template, setTemplate] = useState('Blank')
 
   const onSubmitHandler = () => {
+    const labelSize = _size(label)
+
     if (_isEmpty(label)) {
-      setError('Label empty')
+      setError('Label is empty')
       return
     }
+
+    if (labelSize > 150) {
+      setError(`Strategy name is too long (${labelSize}/150 characters)`)
+      return
+    }
+
     gaCreateStrategy()
 
     onSubmit(label, template)

--- a/src/components/StrategyEditor/StrategyEditorPanel/StrategyEditorPanel.js
+++ b/src/components/StrategyEditor/StrategyEditorPanel/StrategyEditorPanel.js
@@ -11,6 +11,8 @@ import Button from '../../../ui/Button'
 
 import '../style.css'
 
+const MAX_STRATEGY_LABEL_LENGTH = 35
+
 const StrategyEditorPanel = ({
   dark, strategy, onRemove, moveable, children, strategyId, removeable, execRunning, strategyDirty,
   onSaveStrategy, onOpenSelectModal, onOpenCreateModal, onOpenRemoveModal, strategies,
@@ -24,10 +26,10 @@ const StrategyEditorPanel = ({
       label={(
         <>
           Strategy Editor&nbsp;
-          {_size(strategyDisplayLabel) > 35 ? (
+          {_size(strategyDisplayLabel) > MAX_STRATEGY_LABEL_LENGTH ? (
             <Tooltip className='__react-tooltip __react_component_tooltip wide' content={strategyDisplayName}>
               {_truncate(strategyDisplayLabel, {
-                length: 35,
+                length: MAX_STRATEGY_LABEL_LENGTH,
                 omission: '...',
               })}
             </Tooltip>

--- a/src/components/StrategyEditor/StrategyEditorPanel/StrategyEditorPanel.js
+++ b/src/components/StrategyEditor/StrategyEditorPanel/StrategyEditorPanel.js
@@ -2,6 +2,9 @@ import React, { memo } from 'react'
 import { Icon } from 'react-fa'
 import PropTypes from 'prop-types'
 import _isEmpty from 'lodash/isEmpty'
+import _size from 'lodash/size'
+import _truncate from 'lodash/truncate'
+import { Tooltip } from '@ufx-ui/core'
 
 import Panel from '../../../ui/Panel'
 import Button from '../../../ui/Button'
@@ -18,7 +21,21 @@ const StrategyEditorPanel = ({
 
   return (
     <Panel
-      label={`Strategy Editor ${strategyDisplayLabel}`}
+      label={(
+        <>
+          Strategy Editor&nbsp;
+          {_size(strategyDisplayLabel) > 35 ? (
+            <Tooltip className='__react-tooltip __react_component_tooltip wide' content={strategyDisplayName}>
+              {_truncate(strategyDisplayLabel, {
+                length: 35,
+                omission: '...',
+              })}
+            </Tooltip>
+          ) : (
+            strategyDisplayLabel
+          )}
+        </>
+      )}
       className='hfui-strategyeditor__panel'
       dark={dark}
       darkHeader={dark}

--- a/src/index.scss
+++ b/src/index.scss
@@ -140,6 +140,11 @@ body button:focus {
   font-size: 13px;
   padding: 4px 12px;
   text-align: center;
+  
+  &.wide {
+    word-break: break-all;
+    max-width: 650px;
+  }
 }
 
 .__react_component_tooltip {


### PR DESCRIPTION
ASANA Ticket: [Add Limitation to Strategy editor name](https://app.asana.com/0/1125859137800433/1200554799879129/f)

Description:
 - Added limitation for maximum label length (150 chars).
 - Added Tooltip for labels which are too long to display.

UI Demonstration:

https://user-images.githubusercontent.com/35810911/124463327-42bb7300-dd82-11eb-9d85-d4784e551001.mp4

