### PR TITLE
fix: localiseNumber crashing when no input provided

### DIFF
--- a/src/util/ui.js
+++ b/src/util/ui.js
@@ -7,8 +7,8 @@ import _toString from 'lodash/toString'
 import _reverse from 'lodash/reverse'
 
 // takes a number as input and returns a localised version with semicolons in it
-// e.g. '123456789.445566' -> '123,456,789.445566'
-export const localiseNumber = (x) => x.toLocaleString('en-US')
+// e.g. 123456789.445566 -> '123,456,789.445566'
+export const localiseNumber = (x = 'N/A') => x.toLocaleString('en-US')
 
 export const processBalance = (value, localise = true) => {
   let str = _toString(value)


### PR DESCRIPTION
ASANA Ticket: [localiseNumber crashing when no input provided](https://app.asana.com/0/1125859137800433/1200580394882108/f)

Description: When opening Order Form order before HF Connected status becomes green, the app will crash because no input (bid/ask number) is provided to the `localiseNumber` function.
![Screenshot from 2021-07-08 10-19-11](https://user-images.githubusercontent.com/35810911/124987002-d95e8d00-e02b-11eb-9596-fc6084048744.png)

Now the default input is 'N/A':
![Screenshot from 2021-07-08 14-17-27](https://user-images.githubusercontent.com/35810911/124987031-e3808b80-e02b-11eb-8f50-57f3c6684ba0.png)

