### PR TITLE
(feature) StrategyEditor: showing '...' for long strategy names in open strategy modal

### DIFF
--- a/src/components/Navbar/Navbar.LayoutSettings.js
+++ b/src/components/Navbar/Navbar.LayoutSettings.js
@@ -4,7 +4,6 @@ import cx from 'classnames'
 import _entries from 'lodash/entries'
 import _map from 'lodash/map'
 import _get from 'lodash/get'
-import _truncate from 'lodash/truncate'
 
 import OutsideClickHandler from 'react-outside-click-handler'
 import { selectLayout, deleteLayout, saveLayout } from '../../redux/actions/ui'
@@ -17,6 +16,7 @@ import * as Routes from '../../constants/routes'
 
 import AddLayoutComponentModal from '../AddLayoutComponentModal'
 import CreateNewLayoutModal from '../CreateNewLayoutModal'
+import { makeShorterLongName } from '../../util/ui'
 
 const MAX_ID_LENGTH = 30
 
@@ -100,10 +100,7 @@ export default function LayoutSettings() {
                   isSelected={id === layoutID}
                   onClick={() => dispatch(selectLayout(id))}
                 >
-                  {_truncate(id, {
-                    length: MAX_ID_LENGTH,
-                    omission: '...',
-                  })}
+                  {makeShorterLongName(id, MAX_ID_LENGTH)}
                   {layoutDef.canDelete && (
                     <div className='hfui-navbar__layout-settings__delete'>
                       <i className='icon-clear' onClick={() => dispatch(deleteLayout(id))} />

--- a/src/components/OpenExistingStrategyModal/OpenExistingStrategyModal.js
+++ b/src/components/OpenExistingStrategyModal/OpenExistingStrategyModal.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import Debug from 'debug'
 import _isEmpty from 'lodash/isEmpty'
 import _find from 'lodash/find'
+import _truncate from 'lodash/truncate'
 
 import Modal from '../../ui/Modal'
 import Dropdown from '../../ui/Dropdown'
@@ -10,6 +11,8 @@ import Dropdown from '../../ui/Dropdown'
 import './style.css'
 
 const debug = Debug('hfui:c:open-existing-strategy-modal')
+
+const MAX_STRATEGY_LABEL_LENGTH = 60
 
 const OpenExistingStrategyModal = ({
   onClose, strategies, isOpen, onOpen,
@@ -44,7 +47,11 @@ const OpenExistingStrategyModal = ({
         value={strategyID}
         onChange={setStrategyID}
         options={strategies.map(({ label, id }) => ({
-          label, value: id,
+          label: _truncate(label, {
+            length: MAX_STRATEGY_LABEL_LENGTH,
+            omission: '...',
+          }),
+          value: id,
         }))}
       />
 

--- a/src/components/OpenExistingStrategyModal/OpenExistingStrategyModal.js
+++ b/src/components/OpenExistingStrategyModal/OpenExistingStrategyModal.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 import Debug from 'debug'
 import _isEmpty from 'lodash/isEmpty'
 import _find from 'lodash/find'
-import _truncate from 'lodash/truncate'
 
 import Modal from '../../ui/Modal'
+import { makeShorterLongName } from '../../util/ui'
 import Dropdown from '../../ui/Dropdown'
 
 import './style.css'
@@ -47,10 +47,7 @@ const OpenExistingStrategyModal = ({
         value={strategyID}
         onChange={setStrategyID}
         options={strategies.map(({ label, id }) => ({
-          label: _truncate(label, {
-            length: MAX_STRATEGY_LABEL_LENGTH,
-            omission: '...',
-          }),
+          label: makeShorterLongName(label, MAX_STRATEGY_LABEL_LENGTH),
           value: id,
         }))}
       />

--- a/src/components/StrategyEditor/StrategyEditorPanel/StrategyEditorPanel.js
+++ b/src/components/StrategyEditor/StrategyEditorPanel/StrategyEditorPanel.js
@@ -3,10 +3,10 @@ import { Icon } from 'react-fa'
 import PropTypes from 'prop-types'
 import _isEmpty from 'lodash/isEmpty'
 import _size from 'lodash/size'
-import _truncate from 'lodash/truncate'
 import { Tooltip } from '@ufx-ui/core'
 
 import Panel from '../../../ui/Panel'
+import { makeShorterLongName } from '../../../util/ui'
 import Button from '../../../ui/Button'
 
 import '../style.css'
@@ -28,10 +28,7 @@ const StrategyEditorPanel = ({
           Strategy Editor&nbsp;
           {_size(strategyDisplayLabel) > MAX_STRATEGY_LABEL_LENGTH ? (
             <Tooltip className='__react-tooltip __react_component_tooltip wide' content={strategyDisplayName}>
-              {_truncate(strategyDisplayLabel, {
-                length: MAX_STRATEGY_LABEL_LENGTH,
-                omission: '...',
-              })}
+              {makeShorterLongName(strategyDisplayLabel, MAX_STRATEGY_LABEL_LENGTH)}
             </Tooltip>
           ) : (
             strategyDisplayLabel

--- a/src/ui/Panel/index.js
+++ b/src/ui/Panel/index.js
@@ -161,7 +161,7 @@ const Panel = (props) => {
 
 Panel.propTypes = {
   className: PropTypes.string,
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   onRemove: PropTypes.func,
   headerComponents: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
   secondaryHeaderComponents: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),

--- a/src/util/ui.js
+++ b/src/util/ui.js
@@ -5,6 +5,7 @@ import _split from 'lodash/split'
 import _toArray from 'lodash/toArray'
 import _toString from 'lodash/toString'
 import _reverse from 'lodash/reverse'
+import _truncate from 'lodash/truncate'
 
 // takes a number as input and returns a localised version with semicolons in it
 // e.g. 123456789.445566 -> '123,456,789.445566'
@@ -33,3 +34,9 @@ export const processBalance = (value, localise = true) => {
     </>
   )
 }
+
+// if name is longer than a limit - the rest of letters are replaced with '...'
+export const makeShorterLongName = (name, limit) => _truncate(name, {
+  length: limit,
+  omission: '...',
+})


### PR DESCRIPTION
ticket  - https://app.asana.com/0/1200372033300327/1200582533101487

Avoiding duplication of logic

![Снимок экрана от 2021-07-15 18-05-05](https://user-images.githubusercontent.com/81973123/125811660-620d8482-0c5d-479d-a5d8-98a5e3ca4c4b.png)
