### PR TITLE
fix: remove strategy modal for long stategy names

### DIFF
--- a/src/components/RemoveExistingStrategyModal/RemoveExistingStrategyModal.js
+++ b/src/components/RemoveExistingStrategyModal/RemoveExistingStrategyModal.js
@@ -1,16 +1,19 @@
 import React, { useEffect, useState, memo } from 'react'
 import PropTypes from 'prop-types'
+import _size from 'lodash/size'
 import Input from '../../ui/Input'
 import Modal from '../../ui/Modal'
 
+import './style.css'
+
+const MAX_STRATEGY_LABEL_LENGTH = 35
+
 const RemoveExistingStrategyModal = ({
-  isOpen,
-  onRemoveStrategy,
-  onClose,
-  strategy: { label },
+  isOpen, onRemoveStrategy, onClose, strategy: { label },
 }) => {
   const [canDeleteStrategy, setCanDeleteStrategy] = useState(false)
   const [inputValue, setInputValue] = useState('')
+  const isLong = _size(label) > MAX_STRATEGY_LABEL_LENGTH
 
   const removeStrategy = () => {
     onRemoveStrategy()
@@ -36,19 +39,20 @@ const RemoveExistingStrategyModal = ({
     >
       <div className='hfui-removestrategymodal__content'>
         <p>
-          Are you sure you want to delete &nbsp;
-          <b>{ label }</b>
-            &nbsp; strategy?
+          Are you sure you want to delete&nbsp;
+          <b>{label}</b>
+          &nbsp;strategy?
         </p>
         <p>
-          <b>WARNING: </b>
-          <i> This action can not be undone.</i>
+          <b>WARNING:</b>
+          &nbsp;
+          <i>This action can not be undone.</i>
         </p>
         <Input
           type='text'
           value={inputValue}
           onChange={setInputValue}
-          placeholder={`Type "${label}" to delete`}
+          placeholder={`Type ${isLong ? 'the strategy name' : `"${label}"`} to delete it`}
         />
       </div>
       <Modal.Footer>

--- a/src/components/RemoveExistingStrategyModal/style.scss
+++ b/src/components/RemoveExistingStrategyModal/style.scss
@@ -1,0 +1,7 @@
+.hfui-removestrategymodal__wrapper {
+  .hfui-removestrategymodal__content {
+    p {
+      word-break: break-all;
+    }
+  }
+}


### PR DESCRIPTION
ASANA Ticket: [Remove strategy overlapping when the names are too long](https://app.asana.com/0/1125859137800433/1200609319761299/f)

UI Demonstration:
![Screenshot from 2021-07-16 19-04-51](https://user-images.githubusercontent.com/35810911/125976785-7387a39e-c6d1-4e1f-a169-ea97af60e516.png)
![Screenshot from 2021-07-16 19-05-07](https://user-images.githubusercontent.com/35810911/125976786-815ed13a-a1cf-48fb-b462-aebaaaa06062.png)
