### PR TITLE
(improvement) Remove test ticker names

### DIFF
--- a/src/components/ExchangeInfoBar/ExchangeInfoBar.js
+++ b/src/components/ExchangeInfoBar/ExchangeInfoBar.js
@@ -66,8 +66,8 @@ const ExchangeInfoBar = ({
         <div ref={tickerRef} className='hfui-exchangeinfobar__ticker-wrapper'>
           <Ticker
             data={{
-              baseCcy: base,
-              quoteCcy: quote,
+              baseCcy: base.replace(/test/i, ''),
+              quoteCcy: quote.replace(/test/i, ''),
               lastPrice,
               change,
               changePerc,
@@ -79,7 +79,9 @@ const ExchangeInfoBar = ({
             }}
             dataMapping={tickerDataMapping}
             className='hfui-exchangeinfobar__ticker'
-            volumeUnit={tickersVolumeUnit !== 'SELF' ? tickersVolumeUnit : quote}
+            volumeUnit={(tickersVolumeUnit !== 'SELF'
+              ? tickersVolumeUnit
+              : quote).replace(/test/i, '')}
           />
         </div>
         <div

--- a/src/redux/reducers/meta/markets.js
+++ b/src/redux/reducers/meta/markets.js
@@ -8,6 +8,13 @@ const getInitialState = () => {
   return []
 }
 
+const transformTestMarket = (market) => ({
+  ...market,
+  quote: market.quote.replace(/test/gi, ''),
+  base: market.base.replace(/test/gi, ''),
+  uiID: market.uiID.replace(/test/gi, ''),
+})
+
 export default (state = getInitialState(), action = {}) => {
   const { type, payload = {} } = action
 
@@ -15,12 +22,13 @@ export default (state = getInitialState(), action = {}) => {
     case types.DATA_MARKETS: {
       const { markets = [] } = payload
 
-      return markets
+      return _map(markets, transformTestMarket)
     }
 
     case marketTypes.SET_CCY_FULL_NAMES: {
       const { names: [namesArr] } = payload
-      const newState = _map(state, (market) => {
+      const newState = _map(state, (rawMarket) => {
+        const market = transformTestMarket(rawMarket)
         const {
           quote, base, uiID,
         } = market
@@ -55,7 +63,8 @@ export default (state = getInitialState(), action = {}) => {
     }
     case marketTypes.SET_PERPS_NAMES: {
       const { names: [namesArr] } = payload
-      const newState = _map(state, (market) => {
+      const newState = _map(state, (rawMarket) => {
+        const market = transformTestMarket(rawMarket)
         const perpPair = _find(namesArr, (pair) => {
           const [wsID] = pair
           const combinedPair = `${market.base}:${market.quote}`

--- a/src/redux/reducers/meta/markets.js
+++ b/src/redux/reducers/meta/markets.js
@@ -8,7 +8,7 @@ const getInitialState = () => {
   return []
 }
 
-const transformTestMarket = (market) => ({
+const renameTestTickers = (market) => ({
   ...market,
   quote: market.quote.replace(/test/gi, ''),
   base: market.base.replace(/test/gi, ''),
@@ -22,13 +22,13 @@ export default (state = getInitialState(), action = {}) => {
     case types.DATA_MARKETS: {
       const { markets = [] } = payload
 
-      return _map(markets, transformTestMarket)
+      return _map(markets, renameTestTickers)
     }
 
     case marketTypes.SET_CCY_FULL_NAMES: {
       const { names: [namesArr] } = payload
       const newState = _map(state, (rawMarket) => {
-        const market = transformTestMarket(rawMarket)
+        const market = renameTestTickers(rawMarket)
         const {
           quote, base, uiID,
         } = market
@@ -64,7 +64,7 @@ export default (state = getInitialState(), action = {}) => {
     case marketTypes.SET_PERPS_NAMES: {
       const { names: [namesArr] } = payload
       const newState = _map(state, (rawMarket) => {
-        const market = transformTestMarket(rawMarket)
+        const market = renameTestTickers(rawMarket)
         const perpPair = _find(namesArr, (pair) => {
           const [wsID] = pair
           const combinedPair = `${market.base}:${market.quote}`


### PR DESCRIPTION
Removes "TEST" strings from paper trading tickers in the UI:

![image](https://user-images.githubusercontent.com/13964126/125984322-81f18fc4-1ebb-48a5-a565-8d17ed6db767.png)
