### PR TITLE
(fix) clear.sh warnings

### DIFF
--- a/clear.sh
+++ b/clear.sh
@@ -1,3 +1,3 @@
-find ./node_modules -type d -name '*babel*' -maxdepth 1 -exec rm -rf {} \;
-find ./node_modules -type d -name '*css*'   -maxdepth 1 -exec rm -rf {} \;
-find ./node_modules -type d -name '*jest*'  -maxdepth 1 -exec rm -rf {} \;
+find ./node_modules -maxdepth 1 -type d -name '*babel*' -exec rm -rf {} \;
+find ./node_modules -maxdepth 1 -type d -name '*css*' -exec rm -rf {} \;
+find ./node_modules -maxdepth 1 -type d -name '*jest*' -exec rm -rf {} \;


### PR DESCRIPTION
As reported by #574, clear.sh script produces some warnings while running.

Before:
![Screenshot from 2021-08-25 15-46-09](https://user-images.githubusercontent.com/35810911/130802252-38c20353-41a1-499a-a4e4-c1b5d7082103.png)

After:
![Screenshot from 2021-08-25 15-45-42](https://user-images.githubusercontent.com/35810911/130802264-fd446752-5179-4cdd-bb53-cb9fb64efccb.png)
