### PR TITLE
(refactor) ignore CSP header rule for chart-iframe

### DIFF
--- a/public/lib/app.js
+++ b/public/lib/app.js
@@ -1,7 +1,9 @@
 const url = require('url')
 const path = require('path')
+const _omit = require('lodash/omit')
+const _includes = require('lodash/includes')
 const {
-  BrowserWindow, protocol, Menu, shell, ipcMain,
+  BrowserWindow, protocol, Menu, shell, ipcMain, session,
 } = require('electron') // eslint-disable-line
 
 const appMenuTemplate = require('./app_menu_template')
@@ -59,7 +61,7 @@ module.exports = class HFUIApplication {
       }
     })
     this.mainWindow.webContents.on('new-window', this.handleURLRedirect)
-    
+
     ipcMain.on('app-closed', () => {
       this.mainWindow.removeAllListeners('close')
       this.mainWindow.close()
@@ -72,6 +74,21 @@ module.exports = class HFUIApplication {
   }
 
   onReady() {
+
+    session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+      let responseHeaders = { ...details.responseHeaders }
+
+      // for chart-iframe ignore CSP error
+      const chartUrl = 'https://hchart.bitfinex.com'
+      if(details?.url && _includes(details.url, chartUrl)) {
+        responseHeaders = _omit(details.responseHeaders, 'content-security-policy')
+      }
+
+      callback({
+        responseHeaders,
+      })
+    })
+
     protocol.interceptFileProtocol('file', (request, callback) => {
       const fileURL = request.url.substr(7) // all urls start with 'file://'
       callback({ path: path.normalize(`${__dirname}/../${fileURL}`) })


### PR DESCRIPTION
[electron: load chart frame from hchart.bitfinex.com](https://app.asana.com/0/1125859137800433/1201435300092016/f)

Depends: [(refactor) electron: update chart_url](https://github.com/bitfinexcom/bfx-hf-ui-core/pull/193)
