### PR TITLE
use fork for electron-updater

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-ui",
-  "version": "3.31.0-rc.2",
+  "version": "3.30.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-ui",
-  "version": "3.31.0-rc.1",
+  "version": "3.31.0-rc.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-ui",
-  "version": "3.31.0-rc.2",
+  "version": "3.30.1",
   "description": "Official Bitfinex Honey UI - for live trading and executing algorithmic orders/strategies",
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-ui",
-  "version": "3.31.0-rc.1",
+  "version": "3.31.0-rc.2",
   "description": "Official Bitfinex Honey UI - for live trading and executing algorithmic orders/strategies",
   "engines": {
     "node": ">=14"

--- a/public/lib/app.js
+++ b/public/lib/app.js
@@ -3,10 +3,7 @@ const path = require('path')
 const {
   BrowserWindow, protocol, shell, ipcMain, dialog,
 } = require('electron')
-const {
-  NsisUpdater,
-  AppImageUpdater
-} = require('electron-updater')
+const { autoUpdater: _autoUpdater } = require('electron-updater')
 const logger = require('electron-log')
 const enforceMacOSAppLocation = require('../../scripts/enforce-macos-app-location')
 const BfxMacUpdater = require('../../scripts/auto-updater/bfx.mac.updater')
@@ -20,33 +17,16 @@ const syncReadUserSettings = require('../utils/syncReadUserSettings')
 
 const isElectronDebugMode = process.env.REACT_APP_ELECTRON_DEBUG === 'true'
 
-const updaterOptions = {
-  provider: 'github',
-  owner: 'tarcisiozf',
-  repo: 'bfx-hf-ui',
-}
+let autoUpdater = _autoUpdater
 
-let autoUpdater
-
-switch (process.platform) {
-  case 'darwin': {
-    autoUpdater = new BfxMacUpdater(updaterOptions)
-    autoUpdater.addInstallingUpdateEventHandler(() => {
-      return showLoadingWindow({
-        description: 'Updating...',
-        isRequiredToCloseAllWins: true,
-      })
+if (process.platform === 'darwin') {
+  autoUpdater = new BfxMacUpdater()
+  autoUpdater.addInstallingUpdateEventHandler(() => {
+    return showLoadingWindow({
+      description: 'Updating...',
+      isRequiredToCloseAllWins: true,
     })
-    break
-  }
-  case 'win32': {
-    autoUpdater = new NsisUpdater(updaterOptions)
-    break
-  }
-  default: {
-    autoUpdater = new AppImageUpdater(updaterOptions)
-    break
-  }
+  })
 }
 
 autoUpdater.allowPrerelease = false


### PR DESCRIPTION
To test the updater without publishing releases on the final repo, let's use a dev public fork to test during the release-candidate period.

**DISCLAIMER: this code must and will be reverted before the final release**