### PR TITLE
(fix) MacOS fullscreen

### DIFF
--- a/public/lib/app.js
+++ b/public/lib/app.js
@@ -220,6 +220,10 @@ module.exports = class HFUIApplication {
         if (/Could not get code signature/gi.test(err.toString())) {
           return
         }
+        // Skip error when can't find app-update.yml. The error appears in zip packages
+        if (/app-update.yml/gi.test(err.toString())) {
+          return
+        }
 
         this.mainWindow.webContents.send('update_error')
         await hideLoadingWindow({ isRequiredToShowMainWin: false })

--- a/public/lib/app.js
+++ b/public/lib/app.js
@@ -51,6 +51,7 @@ module.exports = class HFUIApplication {
         preload: path.join(__dirname, 'preload.js'),
       },
       fullscreen,
+      fullscreenable: true,
     })
 
     win.loadURL(

--- a/public/utils/appMenu.js
+++ b/public/utils/appMenu.js
@@ -61,7 +61,13 @@ const getTemplate = ({ app, sendOpenSettingsModalMessage }) => {
         {
           label: 'Toggle fullscreen',
           role: 'togglefullscreen',
-          accelerator: 'F11',
+          accelerator: (function getKeys() {
+            const platform = os.platform()
+            if (platform === 'darwin') {
+              return 'Command+F11'
+            }
+            return 'F11'
+          }()),
         },
         {
           label: 'Quit',


### PR DESCRIPTION
ticket - https://app.asana.com/0/1200372033300327/1203004971858308

Using the keyboard shortcut `Cmd+F11` for fullscreen toggle on MacOS, because `F11` is a system shortcut.

branched from https://github.com/bitfinexcom/bfx-hf-ui/pull/745