### PR TITLE
(fix) Pendo Visual Design Studio

### DIFF
--- a/public/constants.js
+++ b/public/constants.js
@@ -10,6 +10,8 @@ const SCRIPT_PATH_API_SERVER = `${SCRIPT_PATH}/start-api-server.js`
 
 const LOCAL_STORE_CWD = `${os.homedir()}/.bitfinexhoney`
 
+const ELECTRON_CONTEXT_ALLOWED_URLS = ['https://app.eu.pendo.io']
+
 module.exports = {
   LOG_PATH,
   LOG_PATH_DS_BITFINEX,
@@ -18,4 +20,5 @@ module.exports = {
   SCRIPT_PATH_DS_BITFINEX,
   SCRIPT_PATH_API_SERVER,
   LOCAL_STORE_CWD,
+  ELECTRON_CONTEXT_ALLOWED_URLS,
 }

--- a/public/lib/app.js
+++ b/public/lib/app.js
@@ -80,7 +80,8 @@ module.exports = class HFUIApplication {
   }
 
   static handleURLRedirect({ url: _url }) {
-    if (ELECTRON_CONTEXT_ALLOWED_URLS.find((extUrl) => _url.includes(extUrl))) {
+    const isURLAllowed = ELECTRON_CONTEXT_ALLOWED_URLS.some((extUrl) => _url?.includes(extUrl))
+    if (isURLAllowed) {
       return {
         action: 'allow',
       }

--- a/public/utils/appMenu.js
+++ b/public/utils/appMenu.js
@@ -44,6 +44,16 @@ const DEBUG_MENU = [
       }
     },
   },
+  {
+    label: 'Pendo Visual Design Studio',
+    click: async (_, focusedWindow) => {
+      if (focusedWindow) {
+        await focusedWindow.webContents.executeJavaScript(
+          'window.pendo?.designerv2.launchInAppDesigner()',
+        )
+      }
+    },
+  },
 ]
 
 const getTemplate = ({ app, sendOpenSettingsModalMessage }) => {


### PR DESCRIPTION
ticket - https://app.asana.com/0/1201849173362898/1203140058772292

Added Pendo Visual Studio button in Diagnostic menu
Using [setWindowOpenHandler](https://www.electronjs.org/ru/docs/latest/api/web-contents#contentssetwindowopenhandlerhandler) instead of [deprecated](https://www.electronjs.org/ru/docs/latest/breaking-changes#removed-webcontents-new-window-event) `new-window` event handler


https://user-images.githubusercontent.com/81973123/212473219-380ab146-62f4-41ba-86b3-9e6646d604ed.mp4


