### PR TITLE
(improvement) Using .env instead of setting variables in the package.json

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+REACT_APP_WSS_URL=ws://localhost:45000
+REACT_APP_DS_URL=ws://localhost:23521
+REACT_APP_UFX_API_URL=http://localhost:45001
+REACT_APP_UFX_PUBLIC_API_URL=http://localhost:45001
+REACT_APP_UFX_WSS_URL=wss://api-pub.bitfinex.com/ws/2
+REACT_APP_IS_ELECTRON_APP=true
+GENERATE_SOURCEMAP=false
+ALGO_LOG=true
+ALGO_LOG_DIR=logs

--- a/.env.example
+++ b/.env.example
@@ -3,12 +3,6 @@ REACT_APP_DS_URL=ws://localhost:23521
 REACT_APP_UFX_API_URL=http://localhost:45001
 REACT_APP_UFX_PUBLIC_API_URL=http://localhost:45001
 REACT_APP_UFX_WSS_URL=wss://api-pub.bitfinex.com/ws/2
-REACT_APP_COOKIE_DOMAIN=bitfinex.com
-
-# production | staging
-REACT_APP_ENVIRONMENT=production
-
-REACT_APP_CHART_URL=https://hchart.bitfinex.com/v0
 REACT_APP_IS_ELECTRON_APP=true
 GENERATE_SOURCEMAP=false
 ALGO_LOG=true

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+REACT_APP_WSS_URL=ws://localhost:45000
+REACT_APP_DS_URL=ws://localhost:23521
+REACT_APP_UFX_API_URL=http://localhost:45001
+REACT_APP_UFX_PUBLIC_API_URL=http://localhost:45001
+REACT_APP_UFX_WSS_URL=wss://api-pub.bitfinex.com/ws/2
+REACT_APP_COOKIE_DOMAIN=bitfinex.com
+
+# production | staging
+REACT_APP_ENVIRONMENT=production
+
+REACT_APP_CHART_URL=https://hchart.bitfinex.com/v0
+REACT_APP_IS_ELECTRON_APP=true
+GENERATE_SOURCEMAP=false
+ALGO_LOG=true
+ALGO_LOG_DIR=logs

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /dist
 
 .DS_Store
-.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/package.json
+++ b/package.json
@@ -80,11 +80,11 @@
     "build-css": "cd ./bfx-hf-ui-core && npm run build-css",
     "watch-css": "cd ./bfx-hf-ui-core && npm run watch-css",
     "start-server": "cross-env concurrently --kill-others \"npm run start-api-server\" \"npm run start-ds-bitfinex\"",
-    "start-api-server": "cross-env ALGO_LOG=true ALGO_LOG_DIR=logs node scripts/start-api-server.js",
+    "start-api-server": "env-cmd node scripts/start-api-server.js",
     "start-ds-bitfinex": "cross-env node scripts/start-ds-bitfinex.js",
-    "start": "cd ./bfx-hf-ui-core && cross-env REACT_APP_DEV=1 REACT_APP_WSS_URL=ws://localhost:45000 REACT_APP_DS_URL=ws://localhost:23521 REACT_APP_UFX_API_URL=http://localhost:45001 REACT_APP_UFX_PUBLIC_API_URL=http://localhost:45001 REACT_APP_UFX_WSS_URL=wss://api-pub.bitfinex.com/ws/2 REACT_APP_IS_ELECTRON_APP=true node scripts/start.js",
+    "start": "cd ./bfx-hf-ui-core && cross-env REACT_APP_DEV=1 env-cmd -f ../.env node scripts/start.js",
     "prebuild": "cd ./bfx-hf-ui-core && git checkout -- .",
-    "build": "npm run fetch-core && npm run update-core && npm run preinstall && cd bfx-hf-ui-core && cross-env GENERATE_SOURCEMAP=false npm run build-css && cross-env REACT_APP_WSS_URL=ws://localhost:45000 REACT_APP_DS_URL=ws://localhost:23521 REACT_APP_UFX_API_URL=http://localhost:45001 REACT_APP_UFX_PUBLIC_API_URL=http://localhost:45001 REACT_APP_UFX_WSS_URL=wss://api-pub.bitfinex.com/ws/2 REACT_APP_IS_ELECTRON_APP=true node scripts/build.js",
+    "build": "npm run fetch-core && npm run update-core && npm run preinstall && cd bfx-hf-ui-core && env-cmd -f ../.env npm run build-css && env-cmd -f ../.env node scripts/build.js",
     "update-core": "git submodule update --remote --merge",
     "fetch-core": "git submodule update --init --recursive",
     "postbuild": "run-script-os",
@@ -150,6 +150,7 @@
     "electron-updater": "^4.6.1",
     "electron-util": "^0.17.2",
     "electron-window-state": "^5.0.3",
+    "env-cmd": "^10.1.0",
     "open": "^7.0.1"
   },
   "browserslist": {


### PR DESCRIPTION
ASANA Ticket: [Cleanup Move env vars out of build/start script](https://app.asana.com/0/1201848935859401/1203020791627955/f)

<img width="1440" alt="Screenshot 2023-02-14 at 23 30 17" src="https://user-images.githubusercontent.com/35810911/218886459-54be798e-4993-4b43-a704-dd4f95472979.png">
(the app is running based on the vars set in the .env file of the bfx-hf-ui repo)